### PR TITLE
WIP - A suggested structure

### DIFF
--- a/src/clients/README.md
+++ b/src/clients/README.md
@@ -1,0 +1,41 @@
+# Building New Client Modules
+
+## TODO:
+
+### add template directory to indicate usage:
+
+* base directory ("/sample") should be named after the API in question.
+* mod.rs should instantiate the internal mods, use them to make them public:
+``` rust
+mod do_something;
+
+pub use do_something::DoSomething // where DoSomething is the Endpoint implementation.
+```
+* mod.rs should define common data structures for the module (i.e. Zone and its children). generally this includes implementation of the APIResult trait for top-level objects
+* individual submodules should define an Endpoint per file. This should include all of the following (where appropriate):
+
+	* Endpoint definition
+	* request structs
+	* response struct(s)
+
+* submodules should include comment block describing endpoint usage.
+
+### Document framework entities
+
+document the Endpoint trait in terms of usage
+document the pieces of an Endpoint trait in terms of usage
+
+### Questions
+
+question: where are error codes defined? should that happen here?
+question: main lib is where all code is, suggestion would be to separate utility (framework) modules from user modules
+question: how does this thing treat "non-standard" api responses; i.e. those responses that do not come back as the standard JSON object? in my framework, i wanted to coerce all responses into this format for consistency's sake, but this may be unwise.
+
+## Suggested structure
+
+extract crate for framework entities and shared mods (Endpoint, APIResponse, etc)
+allow folks to publish their own clients, or publish them here?
+
+tl;dr this feels like a framework. possible future concerns include:
+* internal api nonsense
+* possibility of versioning

--- a/src/zone/list_zones.rs
+++ b/src/zone/list_zones.rs
@@ -1,0 +1,38 @@
+use super::{OrderDirection, SearchMatch};
+use crate::endpoint::{Endpoint, Method};
+use crate::zone::{Status, Zone};
+
+/// List Zones
+/// List, search, sort, and filter your zones
+/// https://api.cloudflare.com/#zone-list-zones
+pub struct ListZones<'a> {
+    pub identifier: &'a str,
+}
+impl<'a> Endpoint<Vec<Zone>, ListZonesParams> for ListZones<'a> {
+    fn method(&self) -> Method {
+        Method::Get
+    }
+    fn path(&self) -> String {
+        "zones".to_string()
+    }
+}
+
+#[derive(Serialize, Clone, Debug, Default)]
+pub struct ListZonesParams {
+    pub name: Option<String>,
+    pub status: Option<Status>,
+    pub page: Option<u32>,
+    pub per_page: Option<u32>,
+    pub order: Option<ListZonesOrder>,
+    pub direction: Option<OrderDirection>,
+    #[serde(rename = "match")]
+    pub search_match: Option<SearchMatch>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum ListZonesOrder {
+    Name,
+    Status,
+    Email,
+}

--- a/src/zone/mod.rs
+++ b/src/zone/mod.rs
@@ -1,59 +1,15 @@
 use super::{OrderDirection, SearchMatch};
 use crate::account::Account;
-use crate::endpoint::{Endpoint, Method};
 use crate::plan::Plan;
 use crate::response::APIResult;
 use chrono::offset::Utc;
 use chrono::DateTime;
 
-/// List Zones
-/// List, search, sort, and filter your zones
-/// https://api.cloudflare.com/#zone-list-zones
-pub struct ListZones<'a> {
-    pub identifier: &'a str,
-}
-impl<'a> Endpoint<Vec<Zone>, ListZonesParams> for ListZones<'a> {
-    fn method(&self) -> Method {
-        Method::Get
-    }
-    fn path(&self) -> String {
-        "zones".to_string()
-    }
-}
+mod list_zones;
+mod zone_details;
 
-/// Zone Details
-/// https://api.cloudflare.com/#zone-zone-details
-pub struct ZoneDetails<'a> {
-    pub identifier: &'a str,
-}
-impl<'a> Endpoint<Zone> for ZoneDetails<'a> {
-    fn method(&self) -> Method {
-        Method::Get
-    }
-    fn path(&self) -> String {
-        format!("zones/{}", self.identifier)
-    }
-}
-
-#[derive(Serialize, Clone, Debug, Default)]
-pub struct ListZonesParams {
-    pub name: Option<String>,
-    pub status: Option<Status>,
-    pub page: Option<u32>,
-    pub per_page: Option<u32>,
-    pub order: Option<ListZonesOrder>,
-    pub direction: Option<OrderDirection>,
-    #[serde(rename = "match")]
-    pub search_match: Option<SearchMatch>,
-}
-
-#[derive(Serialize, Clone, Debug)]
-#[serde(rename_all = "lowercase")]
-pub enum ListZonesOrder {
-    Name,
-    Status,
-    Email,
-}
+pub use list_zones::ListZones;
+pub use zone_details::ZoneDetails;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename = "status", rename_all = "lowercase")]

--- a/src/zone/zone_details.rs
+++ b/src/zone/zone_details.rs
@@ -1,0 +1,16 @@
+use crate::endpoint::{Endpoint, Method};
+use crate::zone::Zone;
+
+/// Zone Details
+/// https://api.cloudflare.com/#zone-zone-details
+pub struct ZoneDetails<'a> {
+    pub identifier: &'a str,
+}
+impl<'a> Endpoint<Zone> for ZoneDetails<'a> {
+    fn method(&self) -> Method {
+        Method::Get
+    }
+    fn path(&self) -> String {
+        format!("zones/{}", self.identifier)
+    }
+}


### PR DESCRIPTION
**NOT INTENDED FOR MERGE**, this is intended to serve as a conversation starter.

This is a v. opinionated first pass at a proposal for extending/guiding contributions to this tool. From what I've discerned from a not-too-deep analysis of the codebase, it appears what we have is actually a framework/library for interacting with v4 Cloudflare APIs, and a series of API-specific client modules that use the framework.

I think that treating these things separately can help to establish the contribution boundaries for potential users; exposing Endpoint, APIResponse, etc as parts of an "external" crate, grants the option for folks to either contribute a client module to this repo, or to develop their own client module alongside their APIs and export their own crate, using this framework as dependency.

This PR includes a `client` directory with a `README` which acts as a draft of a usage / contribution guide for developing a client using the framework. It also includes an example of a client module, converted from the existing `zone` module as an example. Providing this structure and README makes the usage clearer to a newcomer. An additional improvement would include sample unit tests for client endpoints and/or data structures.