### PR TITLE
purging cache

### DIFF
--- a/example/main.rs
+++ b/example/main.rs
@@ -37,6 +37,21 @@ fn print_response<T: APIResult>(response: APIResponse<T>) {
 
 fn zone<APIClientType: APIClient>(arg_matches: &ArgMatches, api_client: &APIClientType) {
     let zone_identifier = arg_matches.value_of("zone_identifier").unwrap();
+    let purge = arg_matches.value_of("purge").unwrap();
+    if purge != "false" {
+        let response = api_client.request(&zone::ZoneCachePurge {
+            identifier: zone_identifier,
+            params: zone::PurgeZoneCacheParams {
+                tags: vec![String::from("")],
+                hosts: vec![String::from("")],
+                files: vec![String::from("")],
+            }
+        });
+
+        print_response(response);
+        return;
+    }
+
     let response = api_client.request(&zone::ZoneDetails {
         identifier: zone_identifier,
     });
@@ -66,7 +81,10 @@ fn mock_api<APIClientType: APIClient>(_args: &ArgMatches, _api: &APIClientType) 
 fn main() -> Result<(), Box<std::error::Error>> {
     let sections = hashmap! {
         "zone" => Section{
-            args: vec![Arg::with_name("zone_identifier").required(true)],
+            args: vec![
+                Arg::with_name("zone_identifier").required(true),
+                Arg::with_name("purge").required(false).long("purge").default_value("false"),
+            ],
             description: "A Zone is a domain name along with its subdomains and other identities",
             function: zone
         },

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -35,6 +35,33 @@ impl<'a> Endpoint<Zone> for ZoneDetails<'a> {
     }
 }
 
+
+/// Zone Details
+/// https://api.cloudflare.com/#zone-purge-files-by-cache-tags-or-host
+pub struct ZoneCachePurge<'a> {
+    pub identifier: &'a str,
+    pub params: PurgeZoneCacheParams,
+}
+
+impl<'a> Endpoint<Zone, (), PurgeZoneCacheParams> for ZoneCachePurge<'a> {
+    fn method(&self) -> Method {
+        Method::Post
+    }
+    fn path(&self) -> String {
+        format!("zones/{}/purge_cache", self.identifier)
+    }
+    fn body(&self) -> Option<PurgeZoneCacheParams> {
+        Some(self.params.clone())
+    }
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct PurgeZoneCacheParams {
+    pub tags: Vec<String>,
+    pub hosts: Vec<String>,
+    pub files: Vec<String>,
+}
+
 #[derive(Serialize, Clone, Debug, Default)]
 pub struct ListZonesParams {
     pub name: Option<String>,


### PR DESCRIPTION
I had this strange case for TreeScale (https://github.com/treescale) where I needed to purge cached assets per zone based on my user actions.

Basically added another struct and parameter type for Zone, probably need to add better example implementation