### PR TITLE
fix #10: add content-type method to Endpoint

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -25,8 +25,10 @@ where
     fn body(&self) -> Option<BodyType> {
         None
     }
-
     fn url(&self, environment: &Environment) -> Url {
         Url::from(environment).join(&self.path()).unwrap()
+    }
+    fn content_type(&self) -> String {
+        "application/json".to_owned()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ impl<'a> APIClient for HTTPAPIClient {
 
         if let Some(body) = endpoint.body() {
             request = request.body(serde_json::to_string(&body).unwrap());
+            request = request.header(reqwest::header::CONTENT_TYPE, endpoint.content_type());
         }
 
         request = request.auth(&self.credentials);


### PR DESCRIPTION
Allows endpoints to configure `"Content-Type"` header. Defaults to `"application/json"`. Blocker for work on https://github.com/cloudflare/wrangler/pull/405.