### PR TITLE
[WIP] Initial attempt at making map_api_response accept non-json api responses

### DIFF
--- a/src/response/apifail.rs
+++ b/src/response/apifail.rs
@@ -46,6 +46,10 @@ impl fmt::Display for ApiError {
 
 pub trait ApiResult: DeserializeOwned + Debug {}
 
+// Ensure that even a raw text response body can be an ApiResult (this takes advantage
+// of the fact that Serde can deserialize strings into... strings).
+impl ApiResult for String {}
+
 
 #[derive(Debug)]
 pub enum ApiFailure {

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -13,6 +13,10 @@ pub struct ApiSuccess<ResultType> {
     pub errors: Vec<ApiError>,
 }
 
+// todo(gabbi): OR we can make this a Result<&dyn some_trait, ApiFailure>?
+// Where this trait exposes accessor methods for two different ApiSuccess structs
+// (ApiJsonSuccess and ApiTextSuccess)? This would be a massive breaking change, though.
+// Users of cloudflare-rs already regularly directly access the .result field in ApiSuccess.
 pub type ApiResponse<ResultType> = Result<ApiSuccess<ResultType>, ApiFailure>;
 
 // If the response is 200 and parses, return Success.
@@ -22,12 +26,31 @@ pub fn map_api_response<ResultType: ApiResult>(
     mut resp: reqwest::Response,
 ) -> ApiResponse<ResultType> {
     if resp.status() == reqwest::StatusCode::OK {
-        let parsed: Result<ApiSuccess<ResultType>, reqwest::Error> = resp.json();
+    
+        // todo(gabbi): Why can't I get resp.headers().get::<ContentType> to work below??
+        let content_type = resp.headers().get("content-type");
+        let parsed: Result<ApiSuccess<ResultType>, reqwest::Error> = match content_type {
+            Some(content_type) if content_type == "octet/string" => { 
+                    // Questionable but maybe workable solution below: take the text from a raw
+                    // text response and put it in the result field of the ApiSuccess struct..?
+                    let body = resp.text().unwrap();
+                    let butt: ApiSuccess<ResultType> = ApiSuccess { 
+                        result: body, 
+                        result_info: None, 
+                        errors: vec![], 
+                        messages: json!(null),
+                    }; 
+                    Ok(butt) 
+                },
+            None => resp.json(), // Default to json parsing.
+        };
+
+        // let parsed: Result<ApiSuccess<ResultType>, reqwest::Error> = response_body;
         match parsed {
             Ok(api_resp) => Ok(api_resp),
             Err(e) => Err(ApiFailure::Invalid(e)),
         }
-    } else {
+    } else { // oddly enough, even if workers KV success responses are raw text, the errors are in json :o
         let parsed: Result<ApiErrors, reqwest::Error> = resp.json();
         let errors = parsed.unwrap_or_default();
         Err(ApiFailure::Error(resp.status(), errors))

--- a/src/workerskv/mod.rs
+++ b/src/workerskv/mod.rs
@@ -1,12 +1,14 @@
 use crate::response::ApiResult;
 use chrono::offset::Utc;
 use chrono::DateTime;
+use serde::ser::{Serialize, Serializer};
 
 pub mod create_namespace;
 pub mod list_namespace_keys;
 pub mod list_namespaces;
 pub mod remove_namespace;
 pub mod rename_namespace;
+pub mod get_value;
 
 /// Workers KV Namespace
 /// A Namespace is a collection of key-value pairs stored in Workers KV.


### PR DESCRIPTION
This PR explores a PoC for one part of #26. It focuses on allowing non-json response bodies to be accepted by cloudflare-rs and returned using the same ApiSuccess.result accessor pattern used by preexisting users of cloudflare-rs.

My questionable first approach to this problem: trying to shove the raw text API response into the ApiSuccess.result field, which should ensure that this change is not breaking, but also fails with
```
error[E0308]: mismatched types
  --> /home/gabbi/github/cloudflare-rs/src/response/mod.rs:39:33
   |
39 |                         result: body, 
   |                                 ^^^^ expected type parameter, found struct `std::string::String`
   |
   = note: expected type `ResultType`
              found type `std::string::String`

```
^ I'm not sure how to get around this (or if this approach even makes much sense in the first place). I floated other ideas in the comments in the code changes.