### PR TITLE
Need to parse KV API times as i64

### DIFF
--- a/src/endpoints/workerskv/mod.rs
+++ b/src/endpoints/workerskv/mod.rs
@@ -1,5 +1,9 @@
 use crate::framework::response::ApiResult;
+use chrono::DateTime;
+use chrono::{TimeZone, Utc};
 use percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
+
+use serde::{Deserialize, Deserializer};
 
 pub mod create_namespace;
 pub mod delete_bulk;
@@ -28,7 +32,23 @@ impl ApiResult for Vec<WorkersKvNamespace> {}
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Key {
     pub name: String,
-    pub expiration: Option<i64>,
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_option_timestamp")]
+    pub expiration: Option<DateTime<Utc>>,
+}
+
+pub fn deserialize_option_timestamp<'de, D>(
+    deserializer: D,
+) -> Result<Option<DateTime<Utc>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: Option<i64> = Option::deserialize(deserializer)?;
+    if let Some(s) = s {
+        return Ok(Some(Utc.timestamp(s, 0)));
+    }
+
+    Ok(None)
 }
 
 impl ApiResult for Key {}

--- a/src/endpoints/workerskv/mod.rs
+++ b/src/endpoints/workerskv/mod.rs
@@ -1,6 +1,4 @@
 use crate::framework::response::ApiResult;
-use chrono::offset::Utc;
-use chrono::DateTime;
 use percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
 
 pub mod create_namespace;

--- a/src/endpoints/workerskv/mod.rs
+++ b/src/endpoints/workerskv/mod.rs
@@ -30,7 +30,7 @@ impl ApiResult for Vec<WorkersKvNamespace> {}
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Key {
     pub name: String,
-    pub expiration: Option<DateTime<Utc>>,
+    pub expiration: Option<i64>,
 }
 
 impl ApiResult for Key {}


### PR DESCRIPTION
This is a small bug fix; the KV API returns i64 values for time, not UTC timestamps. Would love to get this in before we release our upcoming cloudflare-rs version.