### PR TITLE
fixes #32 add validation method to endpoint trait and implement bulk write payload size validation 

### DIFF
--- a/src/endpoints/workerskv/write_bulk.rs
+++ b/src/endpoints/workerskv/write_bulk.rs
@@ -1,5 +1,6 @@
-use crate::framework::endpoint::{Endpoint, Method};
-
+use crate::framework::{response::ApiFailure, response::ApiErrors, response::ApiError, endpoint::{Endpoint, Method}};
+use reqwest;
+use std::collections::HashMap;
 /// Write Key-Value Pairs in Bulk
 /// Writes multiple key-value pairs to Workers KV at once.
 /// A 404 is returned if a write action is for a namespace ID the account doesn't have.
@@ -23,6 +24,26 @@ impl<'a> Endpoint<(), (), Vec<KeyValuePair>> for WriteBulk<'a> {
     fn body(&self) -> Option<Vec<KeyValuePair>> {
         Some(self.bulk_key_value_pairs.clone())
     }
+    fn validate(&self)  -> Result<(), ApiFailure> {
+        if let Some(body) = self.body() {
+            // this matches the serialization in HttpApiClient
+            let len = serde_json::to_string(&body).unwrap().len();
+            if len >= 100_000_000 {
+                return Err(ApiFailure::Error(
+                    reqwest::StatusCode::PAYLOAD_TOO_LARGE,
+                    ApiErrors {
+                        errors: vec![ApiError {
+                            code: 413,
+                            message: "request payload too large, must be less than 100MB".to_owned(),
+                            other: HashMap::new(),
+                        }],
+                        other: HashMap::new(),
+                    },
+                ));
+            }
+        }
+        Ok(())
+    }
     // default content-type is already application/json
 }
 
@@ -34,4 +55,55 @@ pub struct KeyValuePair {
     pub expiration: Option<i64>,
     pub expiration_ttl: Option<i64>,
     pub base64: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_bulk_validator_failure() {
+        let write_bulk_endpoint = WriteBulk{
+            account_identifier: "test_account_id",
+            namespace_identifier: "test_namespace",
+            bulk_key_value_pairs: vec![
+                KeyValuePair {
+                    key: "test".to_owned(),
+                    value: "X".repeat(100_000_000),
+                    expiration: None,
+                    expiration_ttl: None,
+                    base64: None
+                }
+            ]
+        };
+
+        match write_bulk_endpoint.validate() {
+            Ok(_) => assert!(false, "payload too large and validator passed incorrectly"),
+            Err(_) => assert!(true)
+        }
+    }
+
+    #[test]
+    fn write_bulk_validator_success() {
+        let write_bulk_endpoint = WriteBulk{
+            account_identifier: "test_account_id",
+            namespace_identifier: "test_namespace",
+            bulk_key_value_pairs: vec![
+                KeyValuePair {
+                    key: "test".to_owned(),
+                    // max is 99,999,972 chars for the val
+                    // the other 28 chars are taken by the key, property names, and json formatting chars
+                    value: "x".repeat(99_999_950),
+                    expiration: None,
+                    expiration_ttl: None,
+                    base64: None
+                }
+            ]
+        };
+
+        match write_bulk_endpoint.validate() {
+            Ok(_) => assert!(true),
+            Err(_) => assert!(false, "payload within bounds and validator failed incorrectly")
+        }
+    }
 }

--- a/src/framework/endpoint.rs
+++ b/src/framework/endpoint.rs
@@ -1,5 +1,7 @@
 use crate::framework::response::ApiResult;
+use crate::framework::response::ApiFailure;
 use crate::framework::Environment;
+
 use serde::Serialize;
 use url::Url;
 
@@ -10,6 +12,7 @@ pub enum Method {
     Delete,
     Patch,
 }
+
 
 pub trait Endpoint<ResultType = (), QueryType = (), BodyType = ()>
 where
@@ -24,6 +27,10 @@ where
     }
     fn body(&self) -> Option<BodyType> {
         None
+    }
+    /// Some endpoints dont need to validate. That's OK.
+    fn validate(&self) -> Result<(), ApiFailure> {
+        Ok(())
     }
     fn url(&self, environment: &Environment) -> Url {
         Url::from(environment).join(&self.path()).unwrap()

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -80,6 +80,8 @@ impl<'a> ApiClient for HttpApiClient {
             }
         }
 
+        endpoint.validate()?;
+
         // Build the request
         let mut request = self
             .http_client
@@ -97,7 +99,6 @@ impl<'a> ApiClient for HttpApiClient {
         request = request.auth(&self.credentials);
 
         let response = request.send()?;
-
         map_api_response(response)
     }
 }


### PR DESCRIPTION
This is the first rust I have ever written so please take me to the woodshed.

- Add a `fn validate(&self) -> Result<(), ApiFailure>` method to Endpoint trait and default to Ok.
- Implement payload size validation for write_bulk endpoint.
- Tests to confirm behavior. 

Some design decisions/questions:

Originally, I wanted to expose a validator method on the Endpoint trait that returned a ValidatorType that implemented a Validate trait that operated on reqwest::Request. Wow thats a mouth full...

My hope was that I wouldn't need to serialize the body twice and could defer to Request to check Content-Length and/or just call it's internal len() method.
However, I could not do this because *everything* in reqwest:Request is crate private/internally scoped and Content-Length is not set by reqwest until send/execute is called. 
I could pass in the body directly to the validate function and avoid serializing twice, but then the validation would be more tightly coupled to "body" type validation - i.e. what if an endpoint wants to validate query params?

Im open to suggestions on how we can avoid serializing the body twice, yet still support other forms of validations endpoints may want to perform. 
