### PR TITLE
Ensure KV List params are passed into KV namespace list endpoint

### DIFF
--- a/src/endpoints/workerskv/list_namespaces.rs
+++ b/src/endpoints/workerskv/list_namespaces.rs
@@ -7,6 +7,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 /// https://api.cloudflare.com/#workers-kv-namespace-list-namespaces
 pub struct ListNamespaces<'a> {
     pub account_identifier: &'a str,
+    pub params: ListNamespacesParams,
 }
 
 impl<'a> Endpoint<Vec<WorkersKvNamespace>, ListNamespacesParams> for ListNamespaces<'a> {
@@ -15,6 +16,9 @@ impl<'a> Endpoint<Vec<WorkersKvNamespace>, ListNamespacesParams> for ListNamespa
     }
     fn path(&self) -> String {
         format!("accounts/{}/storage/kv/namespaces", self.account_identifier)
+    }
+    fn query(&self) -> Option<ListNamespacesParams> {
+        Some(self.params.clone())
     }
 }
 

--- a/src/endpoints/workerskv/list_namespaces.rs
+++ b/src/endpoints/workerskv/list_namespaces.rs
@@ -22,6 +22,7 @@ impl<'a> Endpoint<Vec<WorkersKvNamespace>, ListNamespacesParams> for ListNamespa
     }
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug, Default)]
 pub struct ListNamespacesParams {
     pub page: Option<u32>,


### PR DESCRIPTION
Previously, these params were actually not usable because they were not accepted as part of the request.