### PR TITLE
Fix #61, 63: async API client

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,26 @@
 # Contributing to cloudflare-rs
 
-There are two root-level modules in `cloudflare-rs`. Most PRs will only touch one of them. If you're
-working on the API framework itself, all the relevant code lives under the `framework/`
-module. If you're adding or editing a particular endpoint, read the "Adding New Endpoints" section below.
+There are two root-level modules in `cloudflare-rs`. Most PRs will only touch one of them. The
+`framework/` module contains the API framework itself. The `endpoints/` module contains code for
+each Cloudflare API endpoint, grouped by product, e.g. `endpoints/dns` or `endpoints/zones`. Check 
+the "Updating the Framework" or "Adding New Endpoints" sections below.
 
 ## Pull Requests
 
-Every PR should have a corresponding issue, and the issue number should appear in the PR's description and commit message.
+Every PR should have a corresponding issue, and the issue number should appear in the PR's 
+description and commit message.
 
 PRs should be squashed to one commit before merging.
+
+## Updating the Framework
+
+This library includes both async and blocking API clients. The `ApiClient` trait covers blocking 
+requests, and is implemented by the `HttpApiClient` struct. The `async_api::Client` struct covers
+async requests. Because Rust doesn't support async fns in traits yet, there is no trait for async
+API clients.
+
+If you want to change how the Cloudflare API client works, please remember to make the change in 
+both blocking and async clients if applicable.
 
 ## Adding New Endpoints
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,20 +21,19 @@ name = "e2e-tests"
 path = "e2e_tests/main.rs"
 
 [dependencies]
+tokio = { version = "0.2", features = ["macros"] } # Only used in bin/e2e, not used in library.
 chrono = { version = "0.4", features = ["serde"] }
-clap = "2.33"
+clap = "2.33" # Only used in binaries, not used in library.
 http = "0.1.18"
 maplit = "1.0"
-reqwest = "0.9"
-serde = "1.0"
-serde_derive = "1.0"
+reqwest = { version = "0.10", features = ["json", "blocking"] }
+serde = {version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.4"
-serde_yaml = "0.8"
 serde_with = "1.3.1"
 slog = "2.4"
 slog-term = "2.4"
 sloggers = "0.3"
-url = "1.7"
+url = "2.1"
 percent-encoding = "1.0.1"
 failure = "0.1.5"

--- a/src/endpoints/load_balancing/mod.rs
+++ b/src/endpoints/load_balancing/mod.rs
@@ -5,7 +5,6 @@ pub mod pool_details;
 use crate::framework::response::ApiResult;
 use chrono::offset::Utc;
 use chrono::DateTime;
-use serde::Deserialize;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::net::IpAddr;

--- a/src/framework/apiclient.rs
+++ b/src/framework/apiclient.rs
@@ -4,7 +4,9 @@ use crate::framework::{
 };
 use serde::Serialize;
 
+/// Synchronously sends requests to the Cloudflare API.
 pub trait ApiClient {
+    /// Synchronously send a request to the Cloudflare API.
     fn request<ResultType, QueryType, BodyType>(
         &self,
         endpoint: &dyn Endpoint<ResultType, QueryType, BodyType>,

--- a/src/framework/async_api.rs
+++ b/src/framework/async_api.rs
@@ -1,0 +1,95 @@
+use crate::framework::{
+    auth,
+    auth::{AuthClient, Credentials},
+    endpoint::Endpoint,
+    reqwest_adaptors::match_reqwest_method,
+    response::{ApiErrors, ApiFailure, ApiSuccess},
+    response::{ApiResponse, ApiResult},
+    Environment, HttpApiClientConfig,
+};
+use reqwest;
+use serde::Serialize;
+
+/// A Cloudflare API client that makes requests asynchronously.
+pub struct Client {
+    environment: Environment,
+    credentials: auth::Credentials,
+    http_client: reqwest::Client,
+}
+
+impl AuthClient for reqwest::RequestBuilder {
+    fn auth(mut self, credentials: &Credentials) -> Self {
+        for (k, v) in credentials.headers() {
+            self = self.header(k, v);
+        }
+        self
+    }
+}
+
+impl Client {
+    pub fn new(
+        credentials: auth::Credentials,
+        config: HttpApiClientConfig,
+        environment: Environment,
+    ) -> Result<Client, failure::Error> {
+        let http_client = reqwest::Client::builder()
+            .timeout(config.http_timeout)
+            .build()?;
+
+        Ok(Client {
+            environment,
+            credentials,
+            http_client,
+        })
+    }
+
+    // Currently, futures/async fns aren't supported in traits, and won't be for a while.
+    // So unlike ApiClient/HttpApiClient, there's no trait with the request method.
+    pub async fn request<ResultType, QueryType, BodyType>(
+        &self,
+        endpoint: &dyn Endpoint<ResultType, QueryType, BodyType>,
+    ) -> ApiResponse<ResultType>
+    where
+        ResultType: ApiResult,
+        QueryType: Serialize,
+        BodyType: Serialize,
+    {
+        // Build the request
+        let mut request = self
+            .http_client
+            .request(
+                match_reqwest_method(endpoint.method()),
+                endpoint.url(&self.environment),
+            )
+            .query(&endpoint.query());
+
+        if let Some(body) = endpoint.body() {
+            request = request.body(serde_json::to_string(&body).unwrap());
+            request = request.header(reqwest::header::CONTENT_TYPE, endpoint.content_type());
+        }
+
+        request = request.auth(&self.credentials);
+        let response = request.send().await?;
+        map_api_response(response).await
+    }
+}
+
+// If the response is 200 and parses, return Success.
+// If the response is 200 and doesn't parse, return Invalid.
+// If the response isn't 200, return Failure, with API errors if they were included.
+async fn map_api_response<ResultType: ApiResult>(
+    resp: reqwest::Response,
+) -> ApiResponse<ResultType> {
+    let status = resp.status();
+    if status == reqwest::StatusCode::OK {
+        let parsed: Result<ApiSuccess<ResultType>, reqwest::Error> = resp.json().await;
+        match parsed {
+            Ok(api_resp) => Ok(api_resp),
+            Err(e) => Err(ApiFailure::Invalid(e)),
+        }
+    } else {
+        let parsed: Result<ApiErrors, reqwest::Error> = resp.json().await;
+        let errors = parsed.unwrap_or_default();
+        Err(ApiFailure::Error(status, errors))
+    }
+}

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -2,17 +2,17 @@
 This module controls how requests are sent to Cloudflare's API, and how responses are parsed from it.
  */
 pub mod apiclient;
+pub mod async_api;
 pub mod auth;
 pub mod endpoint;
 pub mod mock;
+mod reqwest_adaptors;
 pub mod response;
 
-use std::time::Duration;
-
-use crate::framework::{
-    apiclient::ApiClient, auth::AuthClient, endpoint::Method, response::map_api_response,
-};
+use crate::framework::{apiclient::ApiClient, auth::AuthClient, response::map_api_response};
+use reqwest_adaptors::match_reqwest_method;
 use serde::Serialize;
+use std::time::Duration;
 
 #[derive(Serialize, Clone, Debug)]
 pub enum OrderDirection {
@@ -50,10 +50,11 @@ impl<'a> From<&'a Environment> for url::Url {
     }
 }
 
+/// Synchronous Cloudflare API client.
 pub struct HttpApiClient {
     environment: Environment,
     credentials: auth::Credentials,
-    http_client: reqwest::Client,
+    http_client: reqwest::blocking::Client,
 }
 
 pub struct HttpApiClientConfig {
@@ -74,7 +75,7 @@ impl HttpApiClient {
         config: HttpApiClientConfig,
         environment: Environment,
     ) -> Result<HttpApiClient, failure::Error> {
-        let http_client = reqwest::Client::builder()
+        let http_client = reqwest::blocking::Client::builder()
             .timeout(config.http_timeout)
             .build()?;
 
@@ -89,6 +90,7 @@ impl HttpApiClient {
 // TODO: This should probably just implement request for the Reqwest client itself :)
 // TODO: It should also probably be called `ReqwestApiClient` rather than `HttpApiClient`.
 impl<'a> ApiClient for HttpApiClient {
+    /// Synchronously send a request to the Cloudflare API.
     fn request<ResultType, QueryType, BodyType>(
         &self,
         endpoint: &dyn endpoint::Endpoint<ResultType, QueryType, BodyType>,
@@ -98,16 +100,6 @@ impl<'a> ApiClient for HttpApiClient {
         QueryType: Serialize,
         BodyType: Serialize,
     {
-        fn match_reqwest_method(method: Method) -> reqwest::Method {
-            match method {
-                Method::Get => reqwest::Method::GET,
-                Method::Post => reqwest::Method::POST,
-                Method::Delete => reqwest::Method::DELETE,
-                Method::Put => reqwest::Method::PUT,
-                Method::Patch => reqwest::Method::PATCH,
-            }
-        }
-
         // Build the request
         let mut request = self
             .http_client

--- a/src/framework/reqwest_adaptors.rs
+++ b/src/framework/reqwest_adaptors.rs
@@ -1,0 +1,12 @@
+use crate::framework::endpoint::Method;
+use reqwest;
+
+pub fn match_reqwest_method(method: Method) -> reqwest::Method {
+    match method {
+        Method::Get => reqwest::Method::GET,
+        Method::Post => reqwest::Method::POST,
+        Method::Delete => reqwest::Method::DELETE,
+        Method::Put => reqwest::Method::PUT,
+        Method::Patch => reqwest::Method::PATCH,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 ///! An API client for the [Cloudflare API](https://api.cloudflare.com)
 extern crate chrono;
 extern crate reqwest;
-extern crate serde;
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 extern crate serde_json;
 extern crate serde_qs;
 extern crate url;


### PR DESCRIPTION
Features:

- an async API client under `framework::async_api::Client` that works just like `framework::apiclient::ApiClient`, except there's no trait for it (because there's no async fn in traits yet)
- e2e tests updated to use the async client, to prove it works.
- updated some other dependencies

Future work:

You'll notice that `framework/async_api.rs` has some repeated code from `framework/mod.rs` Unfortunately, `reqwest::{request, client, response}` and `reqwest::blocking::{request, client, response}` don't share any traits, so it's not clear how best to share code across the a/sync implementations. I've factored out as much as I can with plain old functions. Please let me know if you have any suggestions for making the code more DRY!