### PR TITLE
CI should use latest stable rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Build
-      run: cargo build --verbose
+      run: rustup update && cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: rustup update && cargo test --verbose


### PR DESCRIPTION
This might fix the problem I'm having in trying to get CI to build code that requires Rust 1.39