### PR TITLE
CI can test multiple os/rust versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,15 +1,19 @@
-name: Rust
+name: Test cloudflare-rs
 
 on: [push]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        rust: [stable]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Build
-      run: rustup update && cargo build --verbose
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: ${{ matrix.rust }}
+    - uses: actions/checkout@master
     - name: Run tests
-      run: rustup update && cargo test --verbose
+      run: cargo test --verbose


### PR DESCRIPTION
@ashleygwilliams suggested our CI should copy from https://github.com/hecrj/setup-rust-action and I Have Obeyed The Wisdom Received.