### PR TITLE
Alewis/fix#68

### DIFF
--- a/example/main.rs
+++ b/example/main.rs
@@ -170,7 +170,9 @@ fn delete_route<ApiClientType: ApiClient>(arg_matches: &ArgMatches, api_client: 
         .expect(&zone_id_missing);
 
     let route_id_missing = format!("missing '{}': {}", "ROUTE_PATTERN", usage);
-    let route_id = arg_matches.value_of("route_id").expect(&route_id_missing);
+    let route_id = arg_matches
+        .value_of("route_identifier")
+        .expect(&route_id_missing);
 
     let response = api_client.request(&workers::DeleteRoute {
         zone_identifier,

--- a/example/main.rs
+++ b/example/main.rs
@@ -4,7 +4,7 @@ extern crate clap;
 extern crate cloudflare;
 
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
-use cloudflare::endpoints::{dns, zone};
+use cloudflare::endpoints::{dns, workers, zone};
 use cloudflare::framework::{
     apiclient::ApiClient,
     auth::Credentials,
@@ -122,6 +122,64 @@ fn create_txt_record<ApiClientType: ApiClient>(
     print_response(response);
 }
 
+fn list_routes<ApiClientType: ApiClient>(arg_matches: &ArgMatches, api_client: &ApiClientType) {
+    let usage = "usage: list_routes ZONE_ID";
+
+    let zone_id_missing = format!("missing '{}': {}", "ZONE_ID", usage);
+    let zone_identifier = arg_matches
+        .value_of("zone_identifier")
+        .expect(&zone_id_missing);
+
+    let response = api_client.request(&workers::ListRoutes { zone_identifier });
+
+    print_response_json(response);
+}
+
+fn create_route<ApiClientType: ApiClient>(arg_matches: &ArgMatches, api_client: &ApiClientType) {
+    let usage = "usage: create_route ZONE_ID SCRIPT_NAME ROUTE_PATTERN";
+
+    let zone_id_missing = format!("missing '{}': {}", "ZONE_ID", usage);
+    let zone_identifier = arg_matches
+        .value_of("zone_identifier")
+        .expect(&zone_id_missing);
+
+    let route_pattern_missing = format!("missing '{}': {}", "ROUTE_PATTERN", usage);
+    let route_pattern = arg_matches
+        .value_of("route_pattern")
+        .expect(&route_pattern_missing);
+
+    let script_name = arg_matches.value_of("script_name");
+
+    let response = api_client.request(&workers::CreateRoute {
+        zone_identifier,
+        params: workers::CreateRouteParams {
+            pattern: route_pattern.to_string(),
+            script: script_name.map(|n| n.to_string()),
+        },
+    });
+
+    print_response_json(response);
+}
+
+fn delete_route<ApiClientType: ApiClient>(arg_matches: &ArgMatches, api_client: &ApiClientType) {
+    let usage = "usage: delete_route ZONE_ID ROUTE_ID";
+
+    let zone_id_missing = format!("missing '{}': {}", "ZONE_ID", usage);
+    let zone_identifier = arg_matches
+        .value_of("zone_identifier")
+        .expect(&zone_id_missing);
+
+    let route_id_missing = format!("missing '{}': {}", "ROUTE_PATTERN", usage);
+    let route_id = arg_matches.value_of("route_id").expect(&route_id_missing);
+
+    let response = api_client.request(&workers::DeleteRoute {
+        zone_identifier,
+        identifier: route_id,
+    });
+
+    print_response_json(response);
+}
+
 fn mock_api<ApiClientType: ApiClient>(_args: &ArgMatches, _api: &ApiClientType) {
     let mock_api = MockApiClient {};
     let endpoint = NoopEndpoint {};
@@ -154,6 +212,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             args: vec![],
             description: "Run a mock API request",
             function: mock_api
+        },
+        "list_routes" => Section{
+            args: vec![
+                Arg::with_name("zone_identifier").required(true),
+            ],
+            description: "Activate a Worker on a Route",
+            function: list_routes
+        },
+        "create_route" => Section{
+            args: vec![
+                Arg::with_name("zone_identifier").required(true),
+                Arg::with_name("route_pattern").required(true),
+                Arg::with_name("script_name").required(false),
+            ],
+            description: "Activate a Worker on a Route",
+            function: create_route
+        },
+        "delete_route" => Section{
+            args: vec![
+                Arg::with_name("zone_identifier").required(true),
+                Arg::with_name("route_identifier").required(true),
+            ],
+            description: "Activate a Worker on a Route",
+            function: delete_route
         },
     };
 

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -8,5 +8,6 @@ pub mod dns;
 pub mod load_balancing;
 pub mod plan;
 pub mod user;
+pub mod workers;
 pub mod workerskv;
 pub mod zone;

--- a/src/endpoints/workers/create_route.rs
+++ b/src/endpoints/workers/create_route.rs
@@ -1,0 +1,29 @@
+use super::WorkersRouteIdOnly;
+
+use crate::framework::endpoint::{Endpoint, Method};
+
+/// Create a Route
+/// Creates a route mapping the given pattern to the given script
+/// https://api.cloudflare.com/#worker-routes-create-route
+pub struct CreateRoute<'a> {
+    pub zone_identifier: &'a str,
+    pub params: CreateRouteParams,
+}
+
+impl<'a> Endpoint<WorkersRouteIdOnly, (), CreateRouteParams> for CreateRoute<'a> {
+    fn method(&self) -> Method {
+        Method::Post
+    }
+    fn path(&self) -> String {
+        format!("zones/{}/workers/routes", self.zone_identifier)
+    }
+    fn body(&self) -> Option<CreateRouteParams> {
+        Some(self.params.clone())
+    }
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct CreateRouteParams {
+    pub pattern: String,
+    pub script: Option<String>,
+}

--- a/src/endpoints/workers/create_route.rs
+++ b/src/endpoints/workers/create_route.rs
@@ -22,6 +22,10 @@ impl<'a> Endpoint<WorkersRouteIdOnly, (), CreateRouteParams> for CreateRoute<'a>
     }
 }
 
+/// pattern: the zone name along with glob-style wildcards
+///         e.g. "example.net/*"
+/// script: Name of the script to apply when the route is matched.
+///         The route is skipped when this is blank/missing.
 #[derive(Serialize, Clone, Debug)]
 pub struct CreateRouteParams {
     pub pattern: String,

--- a/src/endpoints/workers/delete_route.rs
+++ b/src/endpoints/workers/delete_route.rs
@@ -1,0 +1,23 @@
+use super::WorkersRouteIdOnly;
+
+use crate::framework::endpoint::{Endpoint, Method};
+
+/// Delete a Route
+/// Deletes a route by route id
+/// https://api.cloudflare.com/#worker-routes-delete-route
+pub struct DeleteRoute<'a> {
+    pub zone_identifier: &'a str,
+    pub identifier: &'a str,
+}
+
+impl<'a> Endpoint<WorkersRouteIdOnly> for DeleteRoute<'a> {
+    fn method(&self) -> Method {
+        Method::Post
+    }
+    fn path(&self) -> String {
+        format!(
+            "zones/{}/workers/routes/{}",
+            self.zone_identifier, self.identifier
+        )
+    }
+}

--- a/src/endpoints/workers/delete_route.rs
+++ b/src/endpoints/workers/delete_route.rs
@@ -12,7 +12,7 @@ pub struct DeleteRoute<'a> {
 
 impl<'a> Endpoint<WorkersRouteIdOnly> for DeleteRoute<'a> {
     fn method(&self) -> Method {
-        Method::Post
+        Method::Delete
     }
     fn path(&self) -> String {
         format!(

--- a/src/endpoints/workers/list_routes.rs
+++ b/src/endpoints/workers/list_routes.rs
@@ -1,0 +1,19 @@
+use super::WorkersRoute;
+
+use crate::framework::endpoint::{Endpoint, Method};
+
+/// Create a Route
+/// Creates a route mapping the given pattern to the given script
+/// https://api.cloudflare.com/#worker-routes-create-route
+pub struct ListRoutes<'a> {
+    pub zone_identifier: &'a str,
+}
+
+impl<'a> Endpoint<Vec<WorkersRoute>> for ListRoutes<'a> {
+    fn method(&self) -> Method {
+        Method::Get
+    }
+    fn path(&self) -> String {
+        format!("zones/{}/workers/routes", self.zone_identifier)
+    }
+}

--- a/src/endpoints/workers/list_routes.rs
+++ b/src/endpoints/workers/list_routes.rs
@@ -2,9 +2,9 @@ use super::WorkersRoute;
 
 use crate::framework::endpoint::{Endpoint, Method};
 
-/// Create a Route
-/// Creates a route mapping the given pattern to the given script
-/// https://api.cloudflare.com/#worker-routes-create-route
+/// List Routes
+/// Lists all route mappings for a given zone
+/// https://api.cloudflare.com/#worker-routes-list-routes
 pub struct ListRoutes<'a> {
     pub zone_identifier: &'a str,
 }

--- a/src/endpoints/workers/mod.rs
+++ b/src/endpoints/workers/mod.rs
@@ -1,0 +1,39 @@
+use crate::framework::response::ApiResult;
+
+use serde::Deserialize;
+
+mod create_route;
+mod delete_route;
+mod list_routes;
+
+pub use create_route::{CreateRoute, CreateRouteParams};
+pub use delete_route::DeleteRoute;
+pub use list_routes::ListRoutes;
+
+/// Workers KV Route
+/// Routes are basic patterns used to enable or disable workers that match requests.
+/// https://api.cloudflare.com/#worker-routes-properties
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct WorkersRoute {
+    /// Namespace identifier tag.
+    pub id: String,
+    /// The basic pattern that should map to the script
+    pub pattern: String,
+    /// Name of the script to apply when the route is matched.
+    /// The route is skipped when this is blank/missing.
+    pub script: Option<String>,
+}
+
+impl ApiResult for WorkersRoute {}
+impl ApiResult for Vec<WorkersRoute> {}
+
+/// A variant of WorkersRoute returned by the CreateRoute endpoint
+/// We could make `pattern` and `script` into `Option<String>` types
+/// but it feels wrong.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct WorkersRouteIdOnly {
+    /// Namespace identifier tag.
+    pub id: String,
+}
+
+impl ApiResult for WorkersRouteIdOnly {}


### PR DESCRIPTION
I can split things out if it makes sense; this PR adds support for Workers Routes endpoints, specifically Create Route, Delete Route, and List Routes, for use in Wrangler.

It also introduces an alternate print_response function in example/main.rs for outputting json results.