### PR TITLE
Update publish.yml to use new cargo workspace

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
       run: cargo login $CRATES_IO_TOKEN
       env:
         CRATES_IO_TOKEN: ${{ secrets.crates_io_token }} # https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables
+    - name: cd into the library dir
+      run: cd cloudflare
     - name: Dry run publish
       run: cargo publish --dry-run
     - name: Publish


### PR DESCRIPTION
When I did #77 the project structure changed. I forgot to update the release.yml script to use the new project structure.