### PR TITLE
Fix #26: Get response as binary

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -10,6 +10,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 async-trait = "0.1.22"
+bytes = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.1.18"
 reqwest = { version = "0.10", features = ["json", "blocking"] }

--- a/cloudflare/src/framework/apiclient.rs
+++ b/cloudflare/src/framework/apiclient.rs
@@ -5,13 +5,23 @@ use crate::framework::{
 };
 use serde::Serialize;
 
-/// Synchronously sends requests to the Cloudflare API.
+/// Blocks and sends requests to the Cloudflare API.
 pub trait ApiClient {
-    /// Synchronously send a request to the Cloudflare API.
+    /// Block and send a request to the Cloudflare API, deserializing the JSON response.
     fn request<ResultType, QueryType, BodyType>(
         &self,
         endpoint: &dyn Endpoint<ResultType, QueryType, BodyType>,
     ) -> ApiResponse<ResultType>
+    where
+        ResultType: ApiResult,
+        QueryType: Serialize,
+        BodyType: Serialize;
+
+    /// Block and send a request to the Cloudflare API, get the response as bytes.
+    fn request_raw_bytes<ResultType, QueryType, BodyType>(
+        &self,
+        endpoint: &dyn Endpoint<ResultType, QueryType, BodyType>,
+    ) -> Result<Vec<u8>, reqwest::Error>
     where
         ResultType: ApiResult,
         QueryType: Serialize,

--- a/cloudflare/src/framework/mock.rs
+++ b/cloudflare/src/framework/mock.rs
@@ -3,7 +3,9 @@ use crate::framework::async_api;
 use crate::framework::endpoint::{Endpoint, Method};
 use crate::framework::response::{ApiError, ApiErrors, ApiFailure, ApiResponse, ApiResult};
 use async_trait::async_trait;
+use bytes::Bytes;
 use reqwest;
+use serde::Serialize;
 use std::collections::HashMap;
 
 pub struct MockApiClient {}
@@ -45,6 +47,17 @@ impl ApiClient for MockApiClient {
     ) -> ApiResponse<ResultType> {
         Err(mock_response())
     }
+
+    fn request_raw_bytes<ResultType, QueryType, BodyType>(
+        &self,
+        _endpoint: &dyn Endpoint<ResultType, QueryType, BodyType>,
+    ) -> Result<Vec<u8>, reqwest::Error>
+    where
+        QueryType: Serialize,
+        BodyType: Serialize,
+    {
+        Ok(vec![])
+    }
 }
 
 #[async_trait]
@@ -54,5 +67,18 @@ impl async_api::ApiClient for MockApiClient {
         _endpoint: &(dyn Endpoint<ResultType, QueryType, BodyType> + Send + Sync),
     ) -> ApiResponse<ResultType> {
         Err(mock_response())
+    }
+
+    /// Send a request to the Cloudflare API, get the response as bytes.
+    async fn request_raw_bytes<ResultType, QueryType, BodyType>(
+        &self,
+        _endpoint: &(dyn Endpoint<ResultType, QueryType, BodyType> + Send + Sync),
+    ) -> Result<Bytes, reqwest::Error>
+    where
+        ResultType: ApiResult,
+        QueryType: Serialize,
+        BodyType: Serialize,
+    {
+        Ok(Bytes::new())
     }
 }


### PR DESCRIPTION
Workers KV API endpoints return binary responses. This is a problem because our whole API structure assumes responses should be deserialized into JSON.

The simplest solution I've found so far is expanding the `ApiClient` trait. Currently it has one method, `request`. This PR adds a second method, `request_raw_bytes`. Instead of returning JSON, it returns bytes. So:

```rust
fn request          (&dyn Endpoint<ResultType, QueryType, BodyType>) -> ApiResponse<ResultType>
fn request_raw_bytes(&dyn Endpoint<ResultType, QueryType, BodyType>) -> Result<Vec<u8>, reqwest::Error>
```

This is nice, because some customers down the road might not want to deserialize the API responses immediately -- maybe they want to keep them as bytes and send them somewhere else. 

**Improvements for the future**
Currently, you can define an endpoint which should only ever be used with `request_raw_bytes` (like the Workers KV endpoints, which should never be deserialized into JSON). But the compiler won't enforce that. It'd be great if in the future, trying to pass Workers KV endpoint into `request()` is a compile error. 

I tried to implement this, but because `request` already takes a parameter which is `dyn Endpoint`, you can't apply a second trait bound for `trait JsonResponse`. Trying to do so gives you the same error as [this SO question](https://stackoverflow.com/questions/49710852/what-is-an-auto-trait-in-rust)

This is _somewhat_ mitigated by the fact that you can define the binary-only endpoint with `ResultType = ()`, which means that `request()` will return `()`. That can be a signal that the endpoint shouldn't actually deserialize into anything. 