### PR TITLE
Trait for async API clients

### DIFF
--- a/cloudflare-e2e-test/src/main.rs
+++ b/cloudflare-e2e-test/src/main.rs
@@ -1,16 +1,24 @@
 use clap::{App, AppSettings, Arg};
-use cloudflare::framework::{async_api, auth::Credentials, Environment, HttpApiClientConfig};
+use cloudflare::framework::{
+    async_api, async_api::ApiClient, auth::Credentials, Environment, HttpApiClientConfig,
+};
 use failure::{Error, Fallible};
 use std::fmt::Display;
 use std::net::{IpAddr, Ipv4Addr};
 
-async fn tests(api_client: &async_api::Client, account_id: &str) -> Fallible<()> {
-    test_lb_pool(&api_client, &account_id).await?;
+async fn tests<ApiClientType: ApiClient>(
+    api_client: &ApiClientType,
+    account_id: &str,
+) -> Fallible<()> {
+    test_lb_pool(api_client, &account_id).await?;
     println!("Tests passed");
     Ok(())
 }
 
-async fn test_lb_pool(api_client: &async_api::Client, account_identifier: &str) -> Fallible<()> {
+async fn test_lb_pool<ApiClientType: ApiClient>(
+    api_client: &ApiClientType,
+    account_identifier: &str,
+) -> Fallible<()> {
     use cloudflare::endpoints::load_balancing::*;
 
     // Create a pool

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["api-bindings", "web-programming::http-client"]
 license = "BSD-3-Clause"
 
 [dependencies]
+async-trait = "0.1.22"
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.1.18"
 reqwest = { version = "0.10", features = ["json", "blocking"] }

--- a/cloudflare/src/framework/apiclient.rs
+++ b/cloudflare/src/framework/apiclient.rs
@@ -1,3 +1,4 @@
+//! This module contains the synchronous (blocking) API client.
 use crate::framework::{
     endpoint::Endpoint,
     response::{ApiResponse, ApiResult},

--- a/cloudflare/src/framework/mock.rs
+++ b/cloudflare/src/framework/mock.rs
@@ -1,6 +1,8 @@
 use crate::framework::apiclient::ApiClient;
+use crate::framework::async_api;
 use crate::framework::endpoint::{Endpoint, Method};
 use crate::framework::response::{ApiError, ApiErrors, ApiFailure, ApiResponse, ApiResult};
+use async_trait::async_trait;
 use reqwest;
 use std::collections::HashMap;
 
@@ -22,21 +24,35 @@ impl Endpoint<NoopResult> for NoopEndpoint {
 pub struct NoopResult {}
 impl ApiResult for NoopResult {}
 
+fn mock_response() -> ApiFailure {
+    ApiFailure::Error(
+        reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+        ApiErrors {
+            errors: vec![ApiError {
+                code: 9999,
+                message: "This is a mocked failure response".to_owned(),
+                other: HashMap::new(),
+            }],
+            other: HashMap::new(),
+        },
+    )
+}
+
 impl ApiClient for MockApiClient {
     fn request<ResultType, QueryType, BodyType>(
         &self,
         _endpoint: &dyn Endpoint<ResultType, QueryType, BodyType>,
     ) -> ApiResponse<ResultType> {
-        Err(ApiFailure::Error(
-            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
-            ApiErrors {
-                errors: vec![ApiError {
-                    code: 9999,
-                    message: "This is a mocked failure response".to_owned(),
-                    other: HashMap::new(),
-                }],
-                other: HashMap::new(),
-            },
-        ))
+        Err(mock_response())
+    }
+}
+
+#[async_trait]
+impl async_api::ApiClient for MockApiClient {
+    async fn request<ResultType, QueryType, BodyType>(
+        &self,
+        _endpoint: &(dyn Endpoint<ResultType, QueryType, BodyType> + Send + Sync),
+    ) -> ApiResponse<ResultType> {
+        Err(mock_response())
     }
 }


### PR DESCRIPTION
This PR

- Adds an async API trait
- Makes the async API client impl it
- Makes the mock API client impl it
- Updates the e2e tests, to demonstrate that functions can take the async API trait as a parameter (instead of the async API client).

Note this adds a slight bit of overhead for using the async client, because of `dyn`, which has to box the concrete type and put it on the heap (I think). But that's going to be dominated by the cost of the network calls and possibly the serializing/deserializing JSON