### PR TITLE
Fix #26: Binary responses with stronger typing

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -10,6 +10,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 async-trait = "0.1.22"
+bytes = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.1.18"
 reqwest = { version = "0.10", features = ["json", "blocking"] }

--- a/cloudflare/src/framework/apiclient.rs
+++ b/cloudflare/src/framework/apiclient.rs
@@ -1,6 +1,6 @@
 //! This module contains the synchronous (blocking) API client.
 use crate::framework::{
-    endpoint::Endpoint,
+    endpoint::{Binary, Endpoint},
     response::{ApiResponse, ApiResult},
 };
 use serde::Serialize;
@@ -18,12 +18,12 @@ pub trait ApiClient {
         BodyType: Serialize;
 
     /// Block and send a request to the Cloudflare API, get the response as bytes.
-    fn request_raw_bytes<ResultType, QueryType, BodyType>(
+    ///
+    fn request_binary<QueryType, BodyType>(
         &self,
-        endpoint: &dyn Endpoint<ResultType, QueryType, BodyType>,
+        endpoint: &dyn Endpoint<Binary, QueryType, BodyType>,
     ) -> Result<Vec<u8>, reqwest::Error>
     where
-        ResultType: ApiResult,
         QueryType: Serialize,
         BodyType: Serialize;
 }

--- a/cloudflare/src/framework/apiclient.rs
+++ b/cloudflare/src/framework/apiclient.rs
@@ -5,13 +5,23 @@ use crate::framework::{
 };
 use serde::Serialize;
 
-/// Synchronously sends requests to the Cloudflare API.
+/// Blocks and sends requests to the Cloudflare API.
 pub trait ApiClient {
-    /// Synchronously send a request to the Cloudflare API.
+    /// Block and send a request to the Cloudflare API, deserializing the JSON response.
     fn request<ResultType, QueryType, BodyType>(
         &self,
         endpoint: &dyn Endpoint<ResultType, QueryType, BodyType>,
     ) -> ApiResponse<ResultType>
+    where
+        ResultType: ApiResult,
+        QueryType: Serialize,
+        BodyType: Serialize;
+
+    /// Block and send a request to the Cloudflare API, get the response as bytes.
+    fn request_raw_bytes<ResultType, QueryType, BodyType>(
+        &self,
+        endpoint: &dyn Endpoint<ResultType, QueryType, BodyType>,
+    ) -> Result<Vec<u8>, reqwest::Error>
     where
         ResultType: ApiResult,
         QueryType: Serialize,

--- a/cloudflare/src/framework/async_api.rs
+++ b/cloudflare/src/framework/async_api.rs
@@ -1,7 +1,7 @@
 use crate::framework::{
     auth,
     auth::{AuthClient, Credentials},
-    endpoint::Endpoint,
+    endpoint::{Binary, Endpoint},
     reqwest_adaptors::match_reqwest_method,
     response::{ApiErrors, ApiFailure, ApiSuccess},
     response::{ApiResponse, ApiResult},
@@ -26,12 +26,11 @@ pub trait ApiClient {
         BodyType: Serialize;
 
     /// Send a request to a particular Cloudflare API endpoint, get the response as bytes.
-    async fn request_raw_bytes<ResultType, QueryType, BodyType>(
+    async fn request_binary<QueryType, BodyType>(
         &self,
-        endpoint: &(dyn Endpoint<ResultType, QueryType, BodyType> + Send + Sync),
+        endpoint: &(dyn Endpoint<Binary, QueryType, BodyType> + Send + Sync),
     ) -> Result<Bytes, reqwest::Error>
     where
-        ResultType: ApiResult,
         QueryType: Serialize,
         BodyType: Serialize;
 }
@@ -74,7 +73,6 @@ impl Client {
         endpoint: &(dyn Endpoint<ResultType, QueryType, BodyType> + Send + Sync),
     ) -> reqwest::RequestBuilder
     where
-        ResultType: ApiResult,
         QueryType: Serialize,
         BodyType: Serialize,
     {
@@ -114,12 +112,11 @@ impl ApiClient for Client {
     }
 
     /// Send a request to a particular Cloudflare API endpoint, get the response as bytes.
-    async fn request_raw_bytes<ResultType, QueryType, BodyType>(
+    async fn request_binary<QueryType, BodyType>(
         &self,
-        endpoint: &(dyn Endpoint<ResultType, QueryType, BodyType> + Send + Sync),
+        endpoint: &(dyn Endpoint<Binary, QueryType, BodyType> + Send + Sync),
     ) -> Result<Bytes, reqwest::Error>
     where
-        ResultType: ApiResult,
         QueryType: Serialize,
         BodyType: Serialize,
     {

--- a/cloudflare/src/framework/endpoint.rs
+++ b/cloudflare/src/framework/endpoint.rs
@@ -1,4 +1,3 @@
-use crate::framework::response::ApiResult;
 use crate::framework::Environment;
 use serde::Serialize;
 use url::Url;
@@ -11,9 +10,18 @@ pub enum Method {
     Patch,
 }
 
+/// Represents an endpoint in the [Cloudflare API](api.cloudflare.com)
+/// Endpoints accept requests with a certain QueryType and BodyType. They return a certain
+/// ResponseType.
+///
+/// If the endpoint is defined to return a JSON response, simply define a Rust struct `Foo` that
+/// matches that JSON, ensure `impl ApiResult for Foo` and define your endpoint with
+/// `ResultType = Foo`.
+///
+/// If the endpoint is defined to respond with bytes, simply define your endpoint with
+/// `ResultType = endpoint::Binary`.
 pub trait Endpoint<ResultType = (), QueryType = (), BodyType = ()>
 where
-    ResultType: ApiResult,
     QueryType: Serialize,
     BodyType: Serialize,
 {
@@ -32,3 +40,87 @@ where
         "application/json".to_owned()
     }
 }
+
+/// If a Cloudflare API endpoint returns bytes instead of JSON, the `Endpoint` object should be
+/// declared with `ResultType = Binary` and should be accessed with `request_binary`, not `request`.
+///
+/// # Examples
+///
+/// ```
+/// use cloudflare::framework::{
+///     async_api::ApiClient,
+///     endpoint::{Binary, Endpoint, Method},
+/// };
+///
+/// struct BinaryEndpoint {
+///     body_contents: String,
+/// }
+///
+/// impl Endpoint<Binary, (), String> for BinaryEndpoint {
+///     fn method(&self) -> Method {
+///         Method::Post
+///     }
+///     fn path(&self) -> String {
+///         "some/path".to_owned()
+///     }
+///     fn body(&self) -> Option<String> {
+///         Some(self.body_contents.clone())
+///     }
+/// }
+///
+/// fn request_binary<ApiClientType: ApiClient>(api_client: &ApiClientType) {
+///     let req = BinaryEndpoint {
+///         body_contents: "asdf".to_owned(),
+///     };
+///     let _resp = api_client.request_binary(&req);
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use cloudflare::framework::{
+///     async_api::ApiClient,
+///     endpoint::{Binary, Endpoint, Method},
+/// };
+///
+/// struct BinaryEndpoint {
+///     body_contents: String,
+/// }
+///
+/// impl Endpoint<Binary, (), String> for BinaryEndpoint {
+///     fn method(&self) -> Method {
+///         Method::Post
+///     }
+///     fn path(&self) -> String {
+///         "some/path".to_owned()
+///     }
+///     fn body(&self) -> Option<String> {
+///         Some(self.body_contents.clone())
+///     }
+/// }
+///
+/// fn request_binary_into_json<ApiClientType: ApiClient>(api_client: &ApiClientType) {
+///     let req = BinaryEndpoint {
+///         body_contents: "asdf".to_owned(),
+///     };
+///
+///     // This won't compile, because you can't use the `request` method with a binary endpoint.
+///     let _resp = api_client.request(&req);
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use cloudflare::framework::{
+///     async_api::ApiClient,
+///     endpoint::{Binary, Endpoint, Method},
+/// };
+/// use cloudflare::endpoints::account::ListAccounts;
+///
+/// fn request_json_into_binary<ApiClientType: ApiClient>(api_client: &ApiClientType) {
+///     let req = ListAccounts { params: None };
+///
+///     // This won't compile, because you can't use the `request_binary` method with a JSON
+///     // endpoint.
+///     let _resp = api_client.request_binary(&req);
+/// }
+/// ```
+pub enum Binary {}

--- a/cloudflare/src/framework/mock.rs
+++ b/cloudflare/src/framework/mock.rs
@@ -3,7 +3,9 @@ use crate::framework::async_api;
 use crate::framework::endpoint::{Endpoint, Method};
 use crate::framework::response::{ApiError, ApiErrors, ApiFailure, ApiResponse, ApiResult};
 use async_trait::async_trait;
+use bytes::Bytes;
 use reqwest;
+use serde::Serialize;
 use std::collections::HashMap;
 
 pub struct MockApiClient {}
@@ -45,6 +47,17 @@ impl ApiClient for MockApiClient {
     ) -> ApiResponse<ResultType> {
         Err(mock_response())
     }
+
+    fn request_raw_bytes<ResultType, QueryType, BodyType>(
+        &self,
+        _endpoint: &dyn Endpoint<ResultType, QueryType, BodyType>,
+    ) -> Result<Vec<u8>, reqwest::Error>
+    where
+        QueryType: Serialize,
+        BodyType: Serialize,
+    {
+        Ok(vec![])
+    }
 }
 
 #[async_trait]
@@ -54,5 +67,18 @@ impl async_api::ApiClient for MockApiClient {
         _endpoint: &(dyn Endpoint<ResultType, QueryType, BodyType> + Send + Sync),
     ) -> ApiResponse<ResultType> {
         Err(mock_response())
+    }
+
+    /// Send a request to the Cloudflare API, get the response as bytes.
+    async fn request_raw_bytes<ResultType, QueryType, BodyType>(
+        &self,
+        _endpoint: &(dyn Endpoint<ResultType, QueryType, BodyType> + Send + Sync),
+    ) -> Result<Bytes, reqwest::Error>
+    where
+        ResultType: ApiResult,
+        QueryType: Serialize,
+        BodyType: Serialize,
+    {
+        Ok(Bytes::new())
     }
 }

--- a/cloudflare/src/framework/mock.rs
+++ b/cloudflare/src/framework/mock.rs
@@ -1,7 +1,9 @@
-use crate::framework::apiclient::ApiClient;
-use crate::framework::async_api;
-use crate::framework::endpoint::{Endpoint, Method};
-use crate::framework::response::{ApiError, ApiErrors, ApiFailure, ApiResponse, ApiResult};
+use crate::framework::{
+    apiclient::ApiClient,
+    async_api,
+    endpoint::{Binary, Endpoint, Method},
+    response::{ApiError, ApiErrors, ApiFailure, ApiResponse, ApiResult},
+};
 use async_trait::async_trait;
 use bytes::Bytes;
 use reqwest;
@@ -48,9 +50,9 @@ impl ApiClient for MockApiClient {
         Err(mock_response())
     }
 
-    fn request_raw_bytes<ResultType, QueryType, BodyType>(
+    fn request_binary<QueryType, BodyType>(
         &self,
-        _endpoint: &dyn Endpoint<ResultType, QueryType, BodyType>,
+        _endpoint: &dyn Endpoint<Binary, QueryType, BodyType>,
     ) -> Result<Vec<u8>, reqwest::Error>
     where
         QueryType: Serialize,
@@ -70,12 +72,11 @@ impl async_api::ApiClient for MockApiClient {
     }
 
     /// Send a request to the Cloudflare API, get the response as bytes.
-    async fn request_raw_bytes<ResultType, QueryType, BodyType>(
+    async fn request_binary<QueryType, BodyType>(
         &self,
-        _endpoint: &(dyn Endpoint<ResultType, QueryType, BodyType> + Send + Sync),
+        _endpoint: &(dyn Endpoint<Binary, QueryType, BodyType> + Send + Sync),
     ) -> Result<Bytes, reqwest::Error>
     where
-        ResultType: ApiResult,
         QueryType: Serialize,
         BodyType: Serialize,
     {

--- a/cloudflare/src/framework/mod.rs
+++ b/cloudflare/src/framework/mod.rs
@@ -12,7 +12,7 @@ pub mod response;
 use crate::framework::{
     apiclient::ApiClient,
     auth::AuthClient,
-    endpoint::Endpoint,
+    endpoint::{Binary, Endpoint},
     response::{map_api_response, ApiResult},
 };
 use reqwest_adaptors::match_reqwest_method;
@@ -96,7 +96,6 @@ impl HttpApiClient {
         endpoint: &dyn endpoint::Endpoint<ResultType, QueryType, BodyType>,
     ) -> reqwest::blocking::RequestBuilder
     where
-        ResultType: ApiResult,
         QueryType: Serialize,
         BodyType: Serialize,
     {
@@ -139,12 +138,11 @@ impl<'a> ApiClient for HttpApiClient {
     }
 
     /// Synchronously send a request to the Cloudflare API, get the response as bytes.
-    fn request_raw_bytes<ResultType, QueryType, BodyType>(
+    fn request_binary<QueryType, BodyType>(
         &self,
-        endpoint: &dyn Endpoint<ResultType, QueryType, BodyType>,
+        endpoint: &dyn Endpoint<Binary, QueryType, BodyType>,
     ) -> Result<Vec<u8>, reqwest::Error>
     where
-        ResultType: ApiResult,
         QueryType: Serialize,
         BodyType: Serialize,
     {


### PR DESCRIPTION
This PR is based off [PR 84](https://github.com/cloudflare/cloudflare-rs/pull/84) but adds a new commit. Now you have to declare an endpoint as having binary or JSON responses. This is trying to address @sssilver's concern that endpoints should be defined as either binary or JSON, and only be used with one method, either `request` or `request_binary`. 

I added a `Binary` type which can never be instantiated and is not serializable. If you want an endpoint to return binary, use `ResultType = Binary`, so the compiler knows there's no JSON. You can see in the doctests I added that you can't use `ResultType = Binary` endpoints with `request`, and you can't use JSON endpoints with `request_binary`. So now users can't accidentally get a binary/JSON endpoint as JSON/binary :)