### PR TITLE
Bump dependencies

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -9,17 +9,17 @@ categories = ["api-bindings", "web-programming::http-client"]
 license = "BSD-3-Clause"
 
 [dependencies]
-async-trait = "0.1.22"
+async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-http = "0.1.18"
+http = "0.2"
 reqwest = { version = "0.10", features = ["json", "blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.4"
-serde_with = "1.3.1"
+serde_with = "1.3"
 slog = "2.4"
 slog-term = "2.4"
 sloggers = "0.3"
 url = "2.1"
-percent-encoding = "1.0.1"
+percent-encoding = "1.0"
 failure = "0.1.5"


### PR DESCRIPTION
- Bump http from 0.1 to 0.2
- Change dependencies like `foo = x.y.z` to `foo = x.y` because the consumers of a library should be choosing which exact versions to use.