### PR TITLE
Customize client's default headers

### DIFF
--- a/cloudflare/src/framework/async_api.rs
+++ b/cloudflare/src/framework/async_api.rs
@@ -8,6 +8,7 @@ use crate::framework::{
     Environment, HttpApiClientConfig,
 };
 use async_trait::async_trait;
+use failure::Fallible;
 use reqwest;
 use serde::Serialize;
 
@@ -44,9 +45,10 @@ impl Client {
         credentials: auth::Credentials,
         config: HttpApiClientConfig,
         environment: Environment,
-    ) -> Result<Client, failure::Error> {
+    ) -> Fallible<Client> {
         let http_client = reqwest::Client::builder()
             .timeout(config.http_timeout)
+            .default_headers(config.default_headers)
             .build()?;
 
         Ok(Client {


### PR DESCRIPTION
Allows users to set default headers for their HTTP calls.