### PR TITLE
Fixes #26. Allow endpoints to specify a serialization function.

### DIFF
--- a/cloudflare/src/framework/endpoint.rs
+++ b/cloudflare/src/framework/endpoint.rs
@@ -25,6 +25,12 @@ where
     fn body(&self) -> Option<BodyType> {
         None
     }
+    fn serialized_body(&self) -> Option<String> {
+        match self.body() {
+            Some(body) => Some(serde_json::to_string(&body).unwrap()),
+            None => None
+        }
+    }
     fn url(&self, environment: &Environment) -> Url {
         Url::from(environment).join(&self.path()).unwrap()
     }

--- a/cloudflare/src/framework/mod.rs
+++ b/cloudflare/src/framework/mod.rs
@@ -116,8 +116,8 @@ impl<'a> ApiClient for HttpApiClient {
             )
             .query(&endpoint.query());
 
-        if let Some(body) = endpoint.body() {
-            request = request.body(serde_json::to_string(&body).unwrap());
+        if let Some(body) = endpoint.serialized_body() {
+            request = request.body(body);
             request = request.header(reqwest::header::CONTENT_TYPE, endpoint.content_type());
         }
 


### PR DESCRIPTION
This change allows endpoints to specify their own body serialization function, while preserving the current default behavior with a default function in the Endpoint trait, addressing #26 . 

A subsequent PR will demonstrate how this can be used to implement the "Create or update Worker" API endpoint.

More detail in my comment here: https://github.com/cloudflare/cloudflare-rs/issues/26#issuecomment-583869870

