### PR TITLE
Implement create/update and list Workers endpoints

### DIFF
--- a/cloudflare-examples/src/main.rs
+++ b/cloudflare-examples/src/main.rs
@@ -135,6 +135,44 @@ fn list_routes<ApiClientType: ApiClient>(arg_matches: &ArgMatches, api_client: &
     print_response_json(response);
 }
 
+fn list_scripts<ApiClientType: ApiClient>(arg_matches: &ArgMatches, api_client: &ApiClientType) {
+    let usage = "usage: list_scripts ACCOUNT_ID";
+
+    let account_id_missing = format!("missing '{}': {}", "ACCOUNT_ID", usage);
+    let account_identifier = arg_matches
+        .value_of("account_identifier")
+        .expect(&account_id_missing);
+
+    let response = api_client.request(&workers::ListScripts { account_identifier });
+
+    print_response_json(response);
+}
+
+
+fn create_script<ApiClientType: ApiClient>(arg_matches: &ArgMatches, api_client: &ApiClientType) {
+    let usage = "usage: create_script ACCOUNT_ID SCRIPT_NAME";
+
+    let script_name_missing = format!("missing '{}': {}", "SCRIPT_NAME", usage);
+    let script_name = arg_matches
+    .value_of("script_name")
+    .expect(&script_name_missing);
+
+    let script_content = String::from("addEventListener('fetch', event => { event.respondWith(fetch(event.request)) })");
+
+    let account_id_missing = format!("missing '{}': {}", "ACCOUNT_ID", usage);
+    let account_identifier = arg_matches
+    .value_of("account_identifier")
+    .expect(&account_id_missing);
+
+    let response = api_client.request(&workers::CreateScript {
+        account_identifier,
+        script_name,
+        script_content,
+    });
+
+    print_response_json(response);
+}
+
 fn list_accounts<ApiClientType: ApiClient>(_arg_matches: &ArgMatches, api_client: &ApiClientType) {
     let response = api_client.request(&account::ListAccounts { params: None });
 
@@ -227,6 +265,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ],
             description: "Activate a Worker on a Route",
             function: list_routes
+        },
+        "list_scripts" => Section{
+            args: vec![
+                Arg::with_name("account_identifier").required(true),
+            ],
+            description: "List Workers on an account",
+            function: list_scripts
+        },
+        "create_script" => Section{
+            args: vec![
+                Arg::with_name("account_identifier").required(true),
+                Arg::with_name("script_name").required(true),
+            ],
+            description: "Create or update a Worker",
+            function: create_script
         },
         "list_accounts" => Section{
             args: vec![],

--- a/cloudflare/src/endpoints/workers/create_script.rs
+++ b/cloudflare/src/endpoints/workers/create_script.rs
@@ -1,0 +1,30 @@
+use super::WorkersScript;
+
+use crate::framework::endpoint::{Endpoint, Method};
+
+/// Create Script
+/// Create or update a Worker Script.
+/// https://api.cloudflare.com/#worker-script-upload-worker
+pub struct CreateScript<'a> {
+    pub account_identifier: &'a str,
+    pub script_name: &'a str,
+    pub script_content: String,
+}
+
+impl<'a> Endpoint<WorkersScript, (), String> for CreateScript<'a> {
+    fn method(&self) -> Method {
+        Method::Put
+    }
+    fn path(&self) -> String {
+        format!(
+            "accounts/{}/workers/scripts/{}",
+            self.account_identifier, self.script_name
+        )
+    }
+    fn serialized_body(&self) -> Option<String> {
+        Some(self.script_content.clone())
+    }
+    fn content_type(&self) -> String {
+        "application/javascript".to_owned()
+    }
+}

--- a/cloudflare/src/endpoints/workers/list_scripts.rs
+++ b/cloudflare/src/endpoints/workers/list_scripts.rs
@@ -1,0 +1,22 @@
+use super::WorkersScript;
+
+use crate::framework::endpoint::{Endpoint, Method};
+
+/// List Scripts
+/// Lists all scripts for a given account
+/// https://api.cloudflare.com/#worker-script-list-workers
+pub struct ListScripts<'a> {
+    pub account_identifier: &'a str,
+}
+
+impl<'a> Endpoint<Vec<WorkersScript>> for ListScripts<'a> {
+    fn method(&self) -> Method {
+        Method::Get
+    }
+    fn path(&self) -> String {
+        format!(
+            "accounts/{}/workers/scripts",
+            self.account_identifier
+        )
+    }
+}

--- a/cloudflare/src/endpoints/workers/mod.rs
+++ b/cloudflare/src/endpoints/workers/mod.rs
@@ -6,17 +6,21 @@ use serde::Deserialize;
 
 mod create_route;
 mod create_secret;
+mod create_script;
 mod delete_route;
 mod delete_secret;
 mod list_routes;
 mod list_secrets;
+mod list_scripts;
 
 pub use create_route::{CreateRoute, CreateRouteParams};
 pub use create_secret::{CreateSecret, CreateSecretParams};
+pub use create_script::{CreateScript};
 pub use delete_route::DeleteRoute;
 pub use delete_secret::DeleteSecret;
 pub use list_routes::ListRoutes;
 pub use list_secrets::ListSecrets;
+pub use list_scripts::ListScripts;
 
 /// Workers KV Route
 /// Routes are basic patterns used to enable or disable workers that match requests.
@@ -60,3 +64,15 @@ pub struct WorkersSecret {
 
 impl ApiResult for WorkersSecret {}
 impl ApiResult for Vec<WorkersSecret> {} // to parse arrays too
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct WorkersScript {
+    pub id: String,
+    pub etag: String,
+    pub script: Option<String>,
+    pub size: Option<u32>,
+    pub created_on: Option<DateTime<Utc>>,
+    pub modified_on: DateTime<Utc>,
+}
+impl ApiResult for WorkersScript {}
+impl ApiResult for Vec<WorkersScript> {}

--- a/cloudflare/src/framework/endpoint.rs
+++ b/cloudflare/src/framework/endpoint.rs
@@ -25,6 +25,12 @@ where
     fn body(&self) -> Option<BodyType> {
         None
     }
+    fn serialized_body(&self) -> Option<String> {
+        match self.body() {
+            Some(body) => Some(serde_json::to_string(&body).unwrap()),
+            None => None
+        }
+    }
     fn url(&self, environment: &Environment) -> Url {
         Url::from(environment).join(&self.path()).unwrap()
     }

--- a/cloudflare/src/framework/mod.rs
+++ b/cloudflare/src/framework/mod.rs
@@ -116,8 +116,8 @@ impl<'a> ApiClient for HttpApiClient {
             )
             .query(&endpoint.query());
 
-        if let Some(body) = endpoint.body() {
-            request = request.body(serde_json::to_string(&body).unwrap());
+        if let Some(body) = endpoint.serialized_body() {
+            request = request.body(body);
             request = request.header(reqwest::header::CONTENT_TYPE, endpoint.content_type());
         }
 


### PR DESCRIPTION
This builds on changes in https://github.com/cloudflare/cloudflare-rs/pull/105 to implement the simple version of the create/update Worker endpoint, as well as implementing the list Workers endpoint, as described in #104 . Up next can be the multi-part-form create/update method!

... I'm not sure the best way to stage my PRs so that this one clearly depends on my previous one, since I realize each PR should correspond to a single issue. I'd appreciate some guidance :)

To validate this all works as intended:

```
➜  cloudflare-rs git:(ispivey/workers-list-and-create-scripts) cd cloudflare-examples
➜  cloudflare-examples git:(ispivey/workers-list-and-create-scripts) cargo run -- --auth-token=$CF_AUTH_TOKEN create_script $CF_ACCOUNT_ID bleepbloop | jq
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
...
{
  "id": "bleepbloop",
  "etag": "005603661bf9ed84cb3569a53f7caf7c3377e726b37e6064001afb2462ae9845",
  "script": "addEventListener('fetch', event => { event.respondWith(fetch(event.request)) })",
  "size": 127,
  "created_on": "0001-01-01T00:00:00Z",
  "modified_on": "2020-02-09T18:26:34.653254Z"
}
➜  cloudflare-examples git:(ispivey/workers-list-and-create-scripts) cargo run -- --auth-token=$CF_AUTH_TOKEN list_scripts $CF_ACCOUNT_ID | jq
   Compiling cloudflare v0.6.3 (/Users/ispivey/src/cloudflare-rs/cloudflare)
   Compiling cloudflare-examples v0.5.0 (/Users/ispivey/src/cloudflare-rs/cloudflare-examples)
    Finished dev [unoptimized + debuginfo] target(s) in 7.80s
...
[
  {
    "id": "bleepbloop",
    "etag": "005603661bf9ed84cb3569a53f7caf7c3377e726b37e6064001afb2462ae9845",
    "script": null,
    "size": null,
    "created_on": "2020-02-09T02:29:07.292152Z",
    "modified_on": "2020-02-09T17:30:24.938709Z"
  },
...
]
➜  cloudflare-examples git:(ispivey/workers-list-and-create-scripts)
```