### PR TITLE
add default for account struct

### DIFF
--- a/cloudflare/src/endpoints/account/mod.rs
+++ b/cloudflare/src/endpoints/account/mod.rs
@@ -28,5 +28,16 @@ pub struct Settings {
     enforce_twofactor: bool,
 }
 
+/// Cloudflare Accounts Details
+/// An Account is the root object which owns other resources such as zones, load balancers and billing details.
+/// https://api.cloudflare.com/#accounts-properties
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct AccountDetails {
+    /// Account identifier tag.
+    pub id: String,
+    /// Account name
+    pub name: String,
+}
+
 impl ApiResult for Account {}
 impl ApiResult for Vec<Account> {}

--- a/cloudflare/src/endpoints/zone.rs
+++ b/cloudflare/src/endpoints/zone.rs
@@ -1,4 +1,4 @@
-use crate::endpoints::{account::Account, plan::Plan};
+use crate::endpoints::{account::AccountDetails, plan::Plan};
 use crate::framework::{
     endpoint::{Endpoint, Method},
     response::ApiResult,
@@ -113,7 +113,7 @@ pub struct Zone {
     /// The domain name
     pub name: String,
     /// Information about the account the zone belongs to
-    pub account: Account,
+    pub account: AccountDetails,
     /// A list of beta features in which the zone is participating
     pub betas: Option<Vec<String>>,
     /// When the zone was created


### PR DESCRIPTION
When querying the list zones api "GET zones" https://api.cloudflare.com/#zone-list-zones
The account details returned only contain the `id` and the `name` fields therefore create placeholder defaults for the remaining fields in the `Account` struct.