### PR TITLE
Handle getting an empty frequency field for Free Plan

### DIFF
--- a/cloudflare/src/endpoints/plan.rs
+++ b/cloudflare/src/endpoints/plan.rs
@@ -1,5 +1,6 @@
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
+/// Free plans won't have a Frequency, so most responses should accept Option instead.
 pub enum Frequency {
     Weekly,
     Monthly,
@@ -18,7 +19,7 @@ pub struct Plan {
     /// The monetary unit in which pricing information is displayed
     currency: String,
     /// The frequency at which you will be billed for this plan
-    frequency: Frequency,
+    frequency: Option<Frequency>,
     /// A 'friendly' identifier to indicate to the UI what plan the object is
     legacy_id: String,
     /// If the zone is subscribed to this plan


### PR DESCRIPTION
The `frequency` field is empty when on the free plan.