### PR TITLE
Make cloudflare crate usable in wasm32 targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@
 ⚠️ This library is a Work in Progress! ⚠️
 
 This library provides convenience functions that wrap the Cloudflare API.
+
+It provides two client implementations (asynchronous vs blocking). However, 
+projects targeting `wasm32` only get the asynchronous one (as it does not make
+sense to block in that target).

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 base64 = "0.13"
 chrono = { version = "0.4", features = ["serde"] }
+cfg-if = "0.1"
 http = "0.2"
 percent-encoding = "1.0"
 reqwest = { version = "0.10", features = ["json", "blocking"] }

--- a/cloudflare/src/framework/async_api.rs
+++ b/cloudflare/src/framework/async_api.rs
@@ -51,7 +51,7 @@ impl Client {
             .default_headers(config.default_headers);
 
         cfg_if! {
-            // There are no timeouts in wasm.
+            // There are no timeouts in wasm. The property is documented as no-op in wasm32.
             if #[cfg(not(target_arch = "wasm32"))] {
                 builder = builder.timeout(config.http_timeout);
             }
@@ -95,7 +95,8 @@ impl Client {
     }
 }
 
-// The async_trait does not work nicely in wasm.
+// The async_trait does not work nicely in wasm. The mapping of Rust Futures to wasm bindgen
+// Promises does not seem to work when the async_trait macro is used: it causes compilation failures.
 #[cfg(not(target_arch = "wasm32"))]
 #[async_trait]
 impl ApiClient for Client {

--- a/cloudflare/src/framework/auth.rs
+++ b/cloudflare/src/framework/auth.rs
@@ -1,5 +1,3 @@
-use reqwest::blocking::RequestBuilder;
-
 #[derive(Debug)]
 pub enum Credentials {
     UserAuthKey { email: String, key: String },
@@ -23,13 +21,4 @@ impl Credentials {
 
 pub trait AuthClient {
     fn auth(self, credentials: &Credentials) -> Self;
-}
-
-impl AuthClient for RequestBuilder {
-    fn auth(mut self, credentials: &Credentials) -> Self {
-        for (k, v) in credentials.headers() {
-            self = self.header(k, v);
-        }
-        self
-    }
 }

--- a/cloudflare/src/framework/blocking_api.rs
+++ b/cloudflare/src/framework/blocking_api.rs
@@ -1,0 +1,72 @@
+use reqwest::blocking::RequestBuilder;
+use serde::Serialize;
+
+use crate::framework::auth::Credentials;
+use crate::framework::reqwest_adaptors::match_reqwest_method;
+use crate::framework::{
+    apiclient::ApiClient, auth, auth::AuthClient, endpoint, response, response::map_api_response,
+    Environment, HttpApiClient, HttpApiClientConfig,
+};
+
+impl HttpApiClient {
+    pub fn new(
+        credentials: auth::Credentials,
+        config: HttpApiClientConfig,
+        environment: Environment,
+    ) -> anyhow::Result<HttpApiClient> {
+        let http_client = reqwest::blocking::Client::builder()
+            .timeout(config.http_timeout)
+            .default_headers(config.default_headers)
+            .build()?;
+
+        Ok(HttpApiClient {
+            environment,
+            credentials,
+            http_client,
+        })
+    }
+}
+
+// TODO: This should probably just implement request for the Reqwest client itself :)
+// TODO: It should also probably be called `ReqwestApiClient` rather than `HttpApiClient`.
+impl<'a> ApiClient for HttpApiClient {
+    /// Synchronously send a request to the Cloudflare API.
+    fn request<ResultType, QueryType, BodyType>(
+        &self,
+        endpoint: &dyn endpoint::Endpoint<ResultType, QueryType, BodyType>,
+    ) -> response::ApiResponse<ResultType>
+    where
+        ResultType: response::ApiResult,
+        QueryType: Serialize,
+        BodyType: Serialize,
+    {
+        // Build the request
+        let mut request = self
+            .http_client
+            .request(
+                match_reqwest_method(endpoint.method()),
+                endpoint.url(&self.environment),
+            )
+            .query(&endpoint.query());
+
+        if let Some(body) = endpoint.body() {
+            request = request.body(serde_json::to_string(&body).unwrap());
+            request = request.header(reqwest::header::CONTENT_TYPE, endpoint.content_type());
+        }
+
+        request = request.auth(&self.credentials);
+
+        let response = request.send()?;
+
+        map_api_response(response)
+    }
+}
+
+impl AuthClient for RequestBuilder {
+    fn auth(mut self, credentials: &Credentials) -> Self {
+        for (k, v) in credentials.headers() {
+            self = self.header(k, v);
+        }
+        self
+    }
+}

--- a/cloudflare/src/framework/mod.rs
+++ b/cloudflare/src/framework/mod.rs
@@ -4,14 +4,15 @@ This module controls how requests are sent to Cloudflare's API, and how response
 pub mod apiclient;
 pub mod async_api;
 pub mod auth;
+#[cfg(not(target_arch = "wasm32"))]  // There is no blocking implementation for wasm.
+pub mod blocking_api;
 pub mod endpoint;
 pub mod json_utils;
+#[cfg(not(target_arch = "wasm32"))]  // The mock contains a blocking implementation.
 pub mod mock;
 mod reqwest_adaptors;
 pub mod response;
 
-use crate::framework::{apiclient::ApiClient, auth::AuthClient, response::map_api_response};
-use reqwest_adaptors::match_reqwest_method;
 use serde::Serialize;
 use std::time::Duration;
 
@@ -51,6 +52,8 @@ impl<'a> From<&'a Environment> for url::Url {
     }
 }
 
+// There is no blocking support for wasm.
+#[cfg(not(target_arch = "wasm32"))]
 /// Synchronous Cloudflare API client.
 pub struct HttpApiClient {
     environment: Environment,
@@ -72,59 +75,5 @@ impl Default for HttpApiClientConfig {
             http_timeout: Duration::from_secs(30),
             default_headers: http::HeaderMap::default(),
         }
-    }
-}
-
-impl HttpApiClient {
-    pub fn new(
-        credentials: auth::Credentials,
-        config: HttpApiClientConfig,
-        environment: Environment,
-    ) -> anyhow::Result<HttpApiClient> {
-        let http_client = reqwest::blocking::Client::builder()
-            .timeout(config.http_timeout)
-            .default_headers(config.default_headers)
-            .build()?;
-
-        Ok(HttpApiClient {
-            environment,
-            credentials,
-            http_client,
-        })
-    }
-}
-
-// TODO: This should probably just implement request for the Reqwest client itself :)
-// TODO: It should also probably be called `ReqwestApiClient` rather than `HttpApiClient`.
-impl<'a> ApiClient for HttpApiClient {
-    /// Synchronously send a request to the Cloudflare API.
-    fn request<ResultType, QueryType, BodyType>(
-        &self,
-        endpoint: &dyn endpoint::Endpoint<ResultType, QueryType, BodyType>,
-    ) -> response::ApiResponse<ResultType>
-    where
-        ResultType: response::ApiResult,
-        QueryType: Serialize,
-        BodyType: Serialize,
-    {
-        // Build the request
-        let mut request = self
-            .http_client
-            .request(
-                match_reqwest_method(endpoint.method()),
-                endpoint.url(&self.environment),
-            )
-            .query(&endpoint.query());
-
-        if let Some(body) = endpoint.body() {
-            request = request.body(serde_json::to_string(&body).unwrap());
-            request = request.header(reqwest::header::CONTENT_TYPE, endpoint.content_type());
-        }
-
-        request = request.auth(&self.credentials);
-
-        let response = request.send()?;
-
-        map_api_response(response)
     }
 }

--- a/cloudflare/src/framework/mod.rs
+++ b/cloudflare/src/framework/mod.rs
@@ -63,7 +63,9 @@ pub struct HttpApiClient {
 
 /// Configuration for the API client. Allows users to customize its behaviour.
 pub struct HttpApiClientConfig {
-    /// The maximum time limit for an API request. If a request takes longer than this, it will be cancelled.
+    /// The maximum time limit for an API request. If a request takes longer than this, it will be
+    /// cancelled.
+    /// Note: this configuration has no effect when the target is wasm32.
     pub http_timeout: Duration,
     /// A default set of HTTP headers which will be sent with each API request.
     pub default_headers: http::HeaderMap,

--- a/cloudflare/src/framework/response/mod.rs
+++ b/cloudflare/src/framework/response/mod.rs
@@ -15,6 +15,8 @@ pub struct ApiSuccess<ResultType> {
 
 pub type ApiResponse<ResultType> = Result<ApiSuccess<ResultType>, ApiFailure>;
 
+// There is no blocking implementation for wasm.
+#[cfg(not(target_arch = "wasm32"))]
 // If the response is 200 and parses, return Success.
 // If the response is 200 and doesn't parse, return Invalid.
 // If the response isn't 200, return Failure, with API errors if they were included.


### PR DESCRIPTION
    Using the cloudflare in a wasm32 target was failing to compile.
    The first reason being that the blocking client cannot ever work
    in wasm.
    The second reason being that the asynchronous client was using
    the async_trait that did not work fine under wasm_bindgen either.

    As a result, we now hide away those portions of the framework
    implementation when targeting wasm32. We do so by resorting to
    conditional compilation macros.

    To test this out we used the framework to call some endpoints in
    a Cloudflare Worker written in Rust (thus running in wasm) and it
    all worked fine after these changes.

    This thus enables Workers' developers in Rust to use this library
    at will and contribute further to it.