### PR TITLE
Add rustls-tls feature to use rustls with reqwest

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -8,6 +8,11 @@ keywords = ["cloudflare", "api", "client"]
 categories = ["api-bindings", "web-programming::http-client"]
 license = "BSD-3-Clause"
 
+[features]
+default = ["default-tls"]
+default-tls = ["reqwest/default-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
@@ -16,7 +21,7 @@ chrono = { version = "0.4", features = ["serde"] }
 cfg-if = "0.1"
 http = "0.2"
 percent-encoding = "1.0"
-reqwest = { version = "0.11", features = ["json", "blocking"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.4"


### PR DESCRIPTION
Enable rustls in reqwest with 

`cloudflare = { version = "0.7", default-features = false, features = ["rustls-tls"] }`