### PR TITLE
Upgrade to tokio 1.0

### DIFF
--- a/cloudflare-e2e-test/Cargo.toml
+++ b/cloudflare-e2e-test/Cargo.toml
@@ -13,4 +13,4 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = "2.33"
 cloudflare = {path = "../cloudflare"}
 anyhow = "1.0.33"
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1", features = ["macros"] }

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4", features = ["serde"] }
 cfg-if = "0.1"
 http = "0.2"
 percent-encoding = "1.0"
-reqwest = { version = "0.10", features = ["json", "blocking"] }
+reqwest = { version = "0.11", features = ["json", "blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.4"


### PR DESCRIPTION
Now that tokio 1.0 got released and most of the ecosystem has migrated to it, would be great to have this crate support it as well to avoid having to run tokio compatibility crates or multiple runtimes in one app.