### PR TITLE
Fix tail v2 requests

### DIFF
--- a/cloudflare/src/endpoints/workers/mod.rs
+++ b/cloudflare/src/endpoints/workers/mod.rs
@@ -70,7 +70,7 @@ impl ApiResult for Vec<WorkersSecret> {} // to parse arrays too
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct WorkersTail {
     pub id: String,
-    pub url: String,
+    pub url: Option<String>,
     pub expires_at: DateTime<Utc>,
 }
 


### PR DESCRIPTION
When you don't submit a URL to the API, it doesn't give you an API back.

Updating from `String` to `Option<String>` prevents `cloudflare-rs` from
failing when serde fails to deserialize the response -- it's expecting a
url, but there isn't one.
