### PR TITLE
fix: handle possible missing betas field from user details response

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudflare"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Areg Harutyunyan <areg@cloudflare.com>"]
 edition = "2018"
 description = "Rust library for the Cloudflare v4 API"

--- a/cloudflare/src/endpoints/user.rs
+++ b/cloudflare/src/endpoints/user.rs
@@ -19,6 +19,7 @@ pub struct Organization {
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct UserDetails {
     pub organizations: Vec<Organization>,
+    #[serde(default)]
     pub betas: Vec<String>,
     pub telephone: Option<String>,
     pub zipcode: Option<String>,
@@ -34,6 +35,34 @@ pub struct UserDetails {
     pub email: String,
 }
 impl ApiResult for UserDetails {}
+
+#[test]
+fn handles_empty_betas_field() {
+    // note: omitted `betas` field from json data
+    const JSON_RESPONSE: &str = r#"
+    {
+        "id": "1234567890abcdef",
+        "email": "user@example.com",
+        "username": "user",
+        "first_name": null,
+        "last_name": null,
+        "telephone": null,
+        "country": null,
+        "zipcode": null,
+        "two_factor_authentication_enabled": false,
+        "two_factor_authentication_locked": false,
+        "created_on": "2015-02-24T13:03:05.255956Z",
+        "modified_on": "2018-06-10T23:50:04.029596Z",
+        "organizations": [],
+        "has_pro_zones": false,
+        "has_business_zones": false,
+        "has_enterprise_zones": false,
+        "suspended": false
+    }"#;
+
+    let user_details: UserDetails = serde_json::from_str(JSON_RESPONSE).unwrap();
+    assert!(user_details.betas.is_empty());
+}
 
 #[derive(Debug)]
 pub struct GetUserDetails {}


### PR DESCRIPTION
In response to a recent upstream change within the public API, the Wrangler client is seeing some errors, e.g. https://github.com/cloudflare/wrangler/issues/1914

This PR provides a default to the `betas` field which now may likely be empty (and omitted from the API response) in many more cases. The attribute added here is done so that we are not forcing a change on users of this crate to otherwise handle an `Option<Vec<String>>`, but rather encounter an empty vec if `betas` is not present in the json response. 