### PR TITLE
Upgrade reqwest to 0.11.3 for workers wasm support

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -21,7 +21,7 @@ chrono = { version = "0.4", features = ["serde"] }
 cfg-if = "0.1"
 http = "0.2"
 percent-encoding = "1.0"
-reqwest = { version = "0.11", default-features = false, features = ["json", "blocking"] }
+reqwest = { version = "0.11.3", default-features = false, features = ["json", "blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.4"


### PR DESCRIPTION
There's a bug in reqwest 0.11.0 which breaks usage in workers (https://github.com/seanmonstar/reqwest/issues/1247)