### PR TITLE
Allow API endpoints to be configured via an environment variable

### DIFF
--- a/cloudflare-e2e-test/src/main.rs
+++ b/cloudflare-e2e-test/src/main.rs
@@ -134,7 +134,7 @@ async fn main() -> anyhow::Result<()> {
     let api_client = async_api::Client::new(
         credentials,
         HttpApiClientConfig::default(),
-        Environment::Production,
+        Environment::new(),
     )?;
 
     tests(&api_client, &account_id).await

--- a/cloudflare-examples/src/main.rs
+++ b/cloudflare-examples/src/main.rs
@@ -312,7 +312,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_client = HttpApiClient::new(
         credentials,
         HttpApiClientConfig::default(),
-        Environment::Production,
+        Environment::new(),
     )?;
 
     for (section_name, section) in matched_sections {

--- a/cloudflare/src/framework/endpoint.rs
+++ b/cloudflare/src/framework/endpoint.rs
@@ -26,7 +26,7 @@ where
         None
     }
     fn url(&self, environment: &Environment) -> Url {
-        Url::from(environment).join(&self.path()).unwrap()
+        environment.hostname.join(&self.path()).unwrap()
     }
     fn content_type(&self) -> String {
         "application/json".to_owned()


### PR DESCRIPTION
Currently the API endpoints are stored in an Environment enum which has two options: production and custom. This can be redundant to update when users are using the environment enum in multiple location (e.g. changing from prod to another endpoint and vice versa).

This change allows users of the library to configure their API endpoint by using an environment variable (e.g. `ENDPOINT_URL=arbitrary_hostname`) and create a new environment by using `Environment::new()`.
If users don't provide an API endpoint, then the default will be the previous production url.