### PR TITLE
feat: derive clone on credentials

### DIFF
--- a/cloudflare/src/framework/auth.rs
+++ b/cloudflare/src/framework/auth.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Credentials {
     UserAuthKey { email: String, key: String },
     UserAuthToken { token: String },


### PR DESCRIPTION
This PR fixes an error I encountered:

```
the trait bound `Environment: Clone` is not satisfied
```

because one of its members (Credentials) doesn't implement Clone. 