### PR TITLE
meta: bump cargo version to 0.8.7

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudflare"
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Areg Harutyunyan <areg@cloudflare.com>"]
 edition = "2018"
 description = "Rust library for the Cloudflare v4 API"


### PR DESCRIPTION
Prep for new tag and release of `v0.8.7` to crates.io