### PR TITLE
deps: remove unused slog dependencies

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -26,8 +26,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.4"
 serde_with = "1.3"
-slog = "2.5"
-slog-term = "2.6"
-sloggers = "1.0"
 url = "2.2"
 uuid = { version = "0.8", features = ["serde", "v4"] }


### PR DESCRIPTION
We don't use these slog dependencies anywhere. Let's pull them out.