### PR TITLE
responses: make messages and errors default if not present

### DIFF
--- a/cloudflare/src/framework/response/mod.rs
+++ b/cloudflare/src/framework/response/mod.rs
@@ -9,7 +9,9 @@ use serde_json::value::Value as JsonValue;
 pub struct ApiSuccess<ResultType> {
     pub result: ResultType,
     pub result_info: Option<JsonValue>,
+    #[serde(default)]
     pub messages: JsonValue,
+    #[serde(default)]
     pub errors: Vec<ApiError>,
 }
 


### PR DESCRIPTION
Both fields are often not returned by certain cloudflare APIs (the Zero Trust API is a good example). Allowing serde to default them if not present allows these APIs to be used with this crate.