### PR TITLE
Add endpoint to read values from KV

### DIFF
--- a/cloudflare/src/endpoints/workerskv/mod.rs
+++ b/cloudflare/src/endpoints/workerskv/mod.rs
@@ -9,6 +9,7 @@ pub mod delete_bulk;
 pub mod delete_key;
 pub mod list_namespace_keys;
 pub mod list_namespaces;
+pub mod read;
 pub mod remove_namespace;
 pub mod rename_namespace;
 pub mod write_bulk;

--- a/cloudflare/src/endpoints/workerskv/read.rs
+++ b/cloudflare/src/endpoints/workerskv/read.rs
@@ -1,0 +1,31 @@
+use crate::framework::{
+    endpoint::{Endpoint, Method},
+    response::ApiResult,
+};
+
+/// Read a value from Workers KV
+/// Returns the value associated with the given key in the given namespace.
+/// https://api.cloudflare.com/#workers-kv-namespace-read-key-value-pair
+#[derive(Debug)]
+pub struct Read<'a> {
+    pub account_identifier: &'a str,
+    pub namespace_identifier: &'a str,
+    pub key: &'a str,
+}
+
+impl ApiResult for String {}
+
+impl<'a> Endpoint<String, (), ()> for Read<'a> {
+    fn method(&self) -> Method {
+        Method::Get
+    }
+
+    fn path(&self) -> String {
+        format!(
+            "accounts/{}/storage/kv/namespaces/{}/values/{}",
+            self.account_identifier,
+            self.namespace_identifier,
+            super::url_encode_key(self.key)
+        )
+    }
+}


### PR DESCRIPTION
Draft for now since I still need to test if this actually works, but `serde_json` supports deserializing raw strings:

```rust
fn main() {
    let hello: String = serde_json::from_str("\"hello\"").unwrap();
    println!("{hello}")
}
```

```sh
   Compiling json-string v0.1.0 (/Users/cass/Projects/work/json-string)
    Finished dev [unoptimized + debuginfo] target(s) in 1.22s
     Running `target/debug/json-string`
hello
```

The [API Docs](https://api.cloudflare.com/#workers-kv-namespace-read-key-value-pair) indicate that KV just returns a raw string, so...it should work? But I'm going to test it out before marking this PR as ready for review.
