### PR TITLE
Revert "Release 0.9.1 (#180)"

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudflare"
-version = "0.9.1"
+version = "0.9.0"
 authors = ["Areg Harutyunyan <areg@cloudflare.com>"]
 edition = "2018"
 description = "Rust library for the Cloudflare v4 API"


### PR DESCRIPTION
This reverts commit 2793ff07a3cd420856c315b67188bc694a31e818.

The release was not tagged correctly, so we'll do revert the commit so we can do it again.