### PR TITLE
Add resolver IP to HttpApiClientConfig

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudflare"
-version = "0.10.0-alpha.0"
+version = "0.9.1"
 authors = ["Areg Harutyunyan <areg@cloudflare.com>"]
 edition = "2018"
 description = "Rust library for the Cloudflare v4 API"

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudflare"
-version = "0.9.1"
+version = "0.10.0-alpha.0"
 authors = ["Areg Harutyunyan <areg@cloudflare.com>"]
 edition = "2018"
 description = "Rust library for the Cloudflare v4 API"

--- a/cloudflare/src/framework/mod.rs
+++ b/cloudflare/src/framework/mod.rs
@@ -14,6 +14,7 @@ mod reqwest_adaptors;
 pub mod response;
 
 use serde::Serialize;
+use std::net::IpAddr;
 use std::time::Duration;
 
 #[derive(Serialize, Clone, Debug)]
@@ -69,6 +70,8 @@ pub struct HttpApiClientConfig {
     pub http_timeout: Duration,
     /// A default set of HTTP headers which will be sent with each API request.
     pub default_headers: http::HeaderMap,
+    /// A specific IP to use when establishing a connection
+    pub resolve_ip: Option<IpAddr>,
 }
 
 impl Default for HttpApiClientConfig {
@@ -76,6 +79,7 @@ impl Default for HttpApiClientConfig {
         HttpApiClientConfig {
             http_timeout: Duration::from_secs(30),
             default_headers: http::HeaderMap::default(),
+            resolve_ip: None,
         }
     }
 }


### PR DESCRIPTION
This adds an optional field to HttpApiClientConfig that lets you specify a pre-resolved IP address for the API.