### PR TITLE
[RUSTSEC-2020-0071] Replace chrono with time 0.3

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -24,7 +24,7 @@ reqwest = { version = "0.11.4", default-features = false, features = ["json", "b
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.10"
-serde_with = "2.0"
-time = { version = "0.3.17", features = ["serde"] }
+serde_with = { version = "2.0", features = ["time_0_3"] }
+time = "0.3.17"
 url = "2.2"
 uuid = { version = "1.0", features = ["serde", "v4"] }

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -17,7 +17,6 @@ rustls-tls = ["reqwest/rustls-tls"]
 anyhow = "1.0"
 async-trait = "0.1"
 base64 = "0.13"
-chrono = { version = "0.4", features = ["serde"] }
 cfg-if = "1.0"
 http = "0.2"
 percent-encoding = "2.1.0"
@@ -26,5 +25,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.10"
 serde_with = "2.0"
+time = { version = "0.3.17", features = ["serde"] }
 url = "2.2"
 uuid = { version = "1.0", features = ["serde", "v4"] }

--- a/cloudflare/src/endpoints/account/mod.rs
+++ b/cloudflare/src/endpoints/account/mod.rs
@@ -1,5 +1,6 @@
 use crate::framework::response::ApiResult;
 use serde::Deserialize;
+use serde_with::serde_as;
 use time::OffsetDateTime;
 
 pub mod list_accounts;
@@ -8,6 +9,7 @@ pub use list_accounts::ListAccounts;
 /// Cloudflare Accounts
 /// An Account is the root object which owns other resources such as zones, load balancers and billing details.
 /// https://api.cloudflare.com/#accounts-properties
+#[serde_as]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Account {
     /// Account identifier tag.
@@ -17,6 +19,7 @@ pub struct Account {
     /// Account Settings
     pub settings: Option<Settings>,
     /// describes when the account was created
+    #[serde_as(as = "Option<time::format_description::well_known::Rfc3339>")]
     pub created_on: Option<OffsetDateTime>,
 }
 

--- a/cloudflare/src/endpoints/account/mod.rs
+++ b/cloudflare/src/endpoints/account/mod.rs
@@ -1,6 +1,6 @@
 use crate::framework::response::ApiResult;
-use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use time::OffsetDateTime;
 
 pub mod list_accounts;
 pub use list_accounts::ListAccounts;
@@ -17,7 +17,7 @@ pub struct Account {
     /// Account Settings
     pub settings: Option<Settings>,
     /// describes when the account was created
-    pub created_on: Option<DateTime<Utc>>,
+    pub created_on: Option<OffsetDateTime>,
 }
 
 /// Cloudflare Accounts Settings

--- a/cloudflare/src/endpoints/argo_tunnel/data_structures.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/data_structures.rs
@@ -1,4 +1,4 @@
-use chrono::{offset::Utc, DateTime};
+use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::framework::response::ApiResult;
@@ -9,8 +9,8 @@ use crate::framework::response::ApiResult;
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Tunnel {
     pub id: Uuid,
-    pub created_at: DateTime<Utc>,
-    pub deleted_at: Option<DateTime<Utc>>,
+    pub created_at: OffsetDateTime,
+    pub deleted_at: Option<OffsetDateTime>,
     pub name: String,
     pub connections: Vec<ActiveConnection>,
     pub metadata: serde_json::Value,

--- a/cloudflare/src/endpoints/argo_tunnel/data_structures.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/data_structures.rs
@@ -1,3 +1,4 @@
+use serde_with::serde_as;
 use time::OffsetDateTime;
 use uuid::Uuid;
 
@@ -6,10 +7,13 @@ use crate::framework::response::ApiResult;
 /// A Named Argo Tunnel
 /// This is an Argo Tunnel that has been created. It can be used for routing and subsequent running.
 /// https://api.cloudflare.com/#argo-tunnel-properties
+#[serde_as]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Tunnel {
     pub id: Uuid,
+    #[serde_as(as = "time::format_description::well_known::Rfc3339")]
     pub created_at: OffsetDateTime,
+    #[serde_as(as = "Option<time::format_description::well_known::Rfc3339>")]
     pub deleted_at: Option<OffsetDateTime>,
     pub name: String,
     pub connections: Vec<ActiveConnection>,

--- a/cloudflare/src/endpoints/argo_tunnel/list_tunnels.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/list_tunnels.rs
@@ -1,3 +1,4 @@
+use serde_with::serde_as;
 use time::OffsetDateTime;
 
 use crate::framework::endpoint::{Endpoint, Method};
@@ -25,14 +26,17 @@ impl<'a> Endpoint<Vec<Tunnel>, Params> for ListTunnels<'a> {
 }
 
 /// Params for filtering listed tunnels
+#[serde_as]
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug, Default)]
 pub struct Params {
     pub name: Option<String>,
     pub uuid: Option<String>,
     pub is_deleted: Option<bool>,
+    #[serde_as(as = "Option<time::format_description::well_known::Rfc3339>")]
     pub existed_at: Option<OffsetDateTime>,
     pub name_prefix: Option<String>,
+    #[serde_as(as = "Option<time::format_description::well_known::Rfc3339>")]
     pub was_inactive_at: Option<OffsetDateTime>,
     pub exclude_prefix: Option<String>,
     #[serde(flatten)]

--- a/cloudflare/src/endpoints/argo_tunnel/list_tunnels.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/list_tunnels.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use time::OffsetDateTime;
 
 use crate::framework::endpoint::{Endpoint, Method};
 
@@ -31,9 +31,9 @@ pub struct Params {
     pub name: Option<String>,
     pub uuid: Option<String>,
     pub is_deleted: Option<bool>,
-    pub existed_at: Option<DateTime<Utc>>,
+    pub existed_at: Option<OffsetDateTime>,
     pub name_prefix: Option<String>,
-    pub was_inactive_at: Option<DateTime<Utc>>,
+    pub was_inactive_at: Option<OffsetDateTime>,
     pub exclude_prefix: Option<String>,
     #[serde(flatten)]
     pub pagination_params: Option<PaginationParams>,

--- a/cloudflare/src/endpoints/dns.rs
+++ b/cloudflare/src/endpoints/dns.rs
@@ -187,8 +187,10 @@ pub struct DnsRecord {
     /// Zone identifier tag
     pub zone_id: String,
     /// When the record was last modified
+    #[serde(with = "time::serde::rfc3339")]
     pub modified_on: OffsetDateTime,
     /// When the record was created
+    #[serde(with = "time::serde::rfc3339")]
     pub created_on: OffsetDateTime,
     /// Whether this record can be modified/deleted (true means it's managed by Cloudflare)
     pub proxiable: bool,

--- a/cloudflare/src/endpoints/dns.rs
+++ b/cloudflare/src/endpoints/dns.rs
@@ -1,11 +1,11 @@
+use time::OffsetDateTime;
+
 use crate::framework::{
     endpoint::{Endpoint, Method},
     response::ApiResult,
 };
 /// https://api.cloudflare.com/#dns-records-for-a-zone-properties
 use crate::framework::{OrderDirection, SearchMatch};
-use chrono::offset::Utc;
-use chrono::DateTime;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 /// List DNS Records
@@ -187,9 +187,9 @@ pub struct DnsRecord {
     /// Zone identifier tag
     pub zone_id: String,
     /// When the record was last modified
-    pub modified_on: DateTime<Utc>,
+    pub modified_on: OffsetDateTime,
     /// When the record was created
-    pub created_on: DateTime<Utc>,
+    pub created_on: OffsetDateTime,
     /// Whether this record can be modified/deleted (true means it's managed by Cloudflare)
     pub proxiable: bool,
     /// Type of the DNS record that also holds the record value

--- a/cloudflare/src/endpoints/load_balancing/mod.rs
+++ b/cloudflare/src/endpoints/load_balancing/mod.rs
@@ -6,17 +6,16 @@ pub mod list_lb;
 pub mod pool_details;
 
 use crate::framework::response::ApiResult;
-use chrono::offset::Utc;
-use chrono::DateTime;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
+use time::OffsetDateTime;
 
 #[derive(Eq, PartialEq, Deserialize, Serialize, Clone, Debug)]
 pub struct LoadBalancer {
     pub id: String,
-    pub created_on: DateTime<Utc>,
-    pub modified_on: DateTime<Utc>,
+    pub created_on: OffsetDateTime,
+    pub modified_on: OffsetDateTime,
     pub description: String,
     /// The DNS hostname to associate with your Load Balancer. If this hostname already exists as a
     /// DNS record in Cloudflare's DNS, the Load Balancer will take precedence and the DNS record
@@ -122,8 +121,8 @@ impl ApiResult for LoadBalancer {}
 #[derive(Eq, PartialEq, Deserialize, Serialize, Clone, Debug)]
 pub struct Pool {
     pub id: String,
-    pub created_on: DateTime<Utc>,
-    pub modified_on: DateTime<Utc>,
+    pub created_on: OffsetDateTime,
+    pub modified_on: OffsetDateTime,
     /// A human-readable description of the pool.
     /// e.g. "Primary data center - Provider XYZ"
     pub description: String,

--- a/cloudflare/src/endpoints/load_balancing/mod.rs
+++ b/cloudflare/src/endpoints/load_balancing/mod.rs
@@ -14,7 +14,9 @@ use time::OffsetDateTime;
 #[derive(Eq, PartialEq, Deserialize, Serialize, Clone, Debug)]
 pub struct LoadBalancer {
     pub id: String,
+    #[serde(with = "time::serde::rfc3339")]
     pub created_on: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
     pub modified_on: OffsetDateTime,
     pub description: String,
     /// The DNS hostname to associate with your Load Balancer. If this hostname already exists as a
@@ -121,7 +123,9 @@ impl ApiResult for LoadBalancer {}
 #[derive(Eq, PartialEq, Deserialize, Serialize, Clone, Debug)]
 pub struct Pool {
     pub id: String,
+    #[serde(with = "time::serde::rfc3339")]
     pub created_on: OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
     pub modified_on: OffsetDateTime,
     /// A human-readable description of the pool.
     /// e.g. "Primary data center - Provider XYZ"

--- a/cloudflare/src/endpoints/r2.rs
+++ b/cloudflare/src/endpoints/r2.rs
@@ -1,7 +1,6 @@
-use chrono::offset::Utc;
-use chrono::DateTime;
 use serde::Deserialize;
 use std::collections::HashMap;
+use time::OffsetDateTime;
 
 use crate::framework::endpoint::{Endpoint, Method};
 use crate::framework::response::ApiResult;
@@ -12,7 +11,7 @@ pub struct Bucket {
     /// Bucket name
     pub name: String,
     /// Creation date of the bucket
-    pub creation_date: DateTime<Utc>,
+    pub creation_date: OffsetDateTime,
 }
 
 /// ListBucketsResult contains a list of buckets in an account.

--- a/cloudflare/src/endpoints/r2.rs
+++ b/cloudflare/src/endpoints/r2.rs
@@ -11,6 +11,7 @@ pub struct Bucket {
     /// Bucket name
     pub name: String,
     /// Creation date of the bucket
+    #[serde(with = "time::serde::rfc3339")]
     pub creation_date: OffsetDateTime,
 }
 

--- a/cloudflare/src/endpoints/user.rs
+++ b/cloudflare/src/endpoints/user.rs
@@ -24,8 +24,10 @@ pub struct UserDetails {
     pub telephone: Option<String>,
     pub zipcode: Option<String>,
     pub last_name: Option<String>,
+    #[serde(with = "time::serde::rfc3339")]
     pub modified_on: OffsetDateTime,
     pub username: String,
+    #[serde(with = "time::serde::rfc3339")]
     pub created_on: OffsetDateTime,
     pub country: Option<String>,
     pub two_factor_authentication_enabled: bool,

--- a/cloudflare/src/endpoints/user.rs
+++ b/cloudflare/src/endpoints/user.rs
@@ -1,7 +1,7 @@
 use crate::framework::endpoint::{Endpoint, Method};
 use crate::framework::response::ApiResult;
 
-use chrono::{DateTime, Utc};
+use time::OffsetDateTime;
 
 /// Get User Details
 /// Gets information about a user
@@ -24,9 +24,9 @@ pub struct UserDetails {
     pub telephone: Option<String>,
     pub zipcode: Option<String>,
     pub last_name: Option<String>,
-    pub modified_on: DateTime<Utc>,
+    pub modified_on: OffsetDateTime,
     pub username: String,
-    pub created_on: DateTime<Utc>,
+    pub created_on: OffsetDateTime,
     pub country: Option<String>,
     pub two_factor_authentication_enabled: bool,
     pub first_name: Option<String>,

--- a/cloudflare/src/endpoints/workers/mod.rs
+++ b/cloudflare/src/endpoints/workers/mod.rs
@@ -77,6 +77,7 @@ impl ApiResult for Vec<WorkersSecret> {} // to parse arrays too
 pub struct WorkersTail {
     pub id: String,
     pub url: Option<String>,
+    #[serde(with = "time::serde::rfc3339")]
     pub expires_at: OffsetDateTime,
 }
 

--- a/cloudflare/src/endpoints/workers/mod.rs
+++ b/cloudflare/src/endpoints/workers/mod.rs
@@ -1,7 +1,7 @@
 use crate::framework::response::ApiResult;
 
-use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use time::OffsetDateTime;
 
 mod create_route;
 mod create_secret;
@@ -77,7 +77,7 @@ impl ApiResult for Vec<WorkersSecret> {} // to parse arrays too
 pub struct WorkersTail {
     pub id: String,
     pub url: Option<String>,
-    pub expires_at: DateTime<Utc>,
+    pub expires_at: OffsetDateTime,
 }
 
 impl ApiResult for WorkersTail {}

--- a/cloudflare/src/endpoints/workerskv/mod.rs
+++ b/cloudflare/src/endpoints/workerskv/mod.rs
@@ -1,6 +1,7 @@
 use crate::framework::response::ApiResult;
 use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
+use serde_with::{serde_as, TimestampSeconds};
 use time::OffsetDateTime;
 
 pub mod create_namespace;
@@ -52,27 +53,13 @@ impl ApiResult for WorkersKvNamespace {}
 
 impl ApiResult for Vec<WorkersKvNamespace> {}
 
+#[serde_as]
 #[serde_with::skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Key {
     pub name: String,
-    #[serde(default)]
-    #[serde(deserialize_with = "deserialize_option_timestamp")]
+    #[serde_as(as = "Option<TimestampSeconds<i64>>")]
     pub expiration: Option<OffsetDateTime>,
-}
-
-pub fn deserialize_option_timestamp<'de, D>(
-    deserializer: D,
-) -> Result<Option<OffsetDateTime>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s: Option<i64> = Option::deserialize(deserializer)?;
-    if let Some(s) = s {
-        return Ok(OffsetDateTime::from_unix_timestamp(s).ok());
-    }
-
-    Ok(None)
 }
 
 impl ApiResult for Key {}

--- a/cloudflare/src/endpoints/workerskv/mod.rs
+++ b/cloudflare/src/endpoints/workerskv/mod.rs
@@ -1,8 +1,7 @@
 use crate::framework::response::ApiResult;
-use chrono::DateTime;
-use chrono::{TimeZone, Utc};
 use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
 use serde::{Deserialize, Deserializer};
+use time::OffsetDateTime;
 
 pub mod create_namespace;
 pub mod delete_bulk;
@@ -59,18 +58,18 @@ pub struct Key {
     pub name: String,
     #[serde(default)]
     #[serde(deserialize_with = "deserialize_option_timestamp")]
-    pub expiration: Option<DateTime<Utc>>,
+    pub expiration: Option<OffsetDateTime>,
 }
 
 pub fn deserialize_option_timestamp<'de, D>(
     deserializer: D,
-) -> Result<Option<DateTime<Utc>>, D::Error>
+) -> Result<Option<OffsetDateTime>, D::Error>
 where
     D: Deserializer<'de>,
 {
     let s: Option<i64> = Option::deserialize(deserializer)?;
     if let Some(s) = s {
-        return Ok(Utc.timestamp_opt(s, 0).single());
+        return Ok(OffsetDateTime::from_unix_timestamp(s).ok());
     }
 
     Ok(None)

--- a/cloudflare/src/endpoints/zone.rs
+++ b/cloudflare/src/endpoints/zone.rs
@@ -147,6 +147,7 @@ pub struct Zone {
     /// A list of beta features in which the zone is participating
     pub betas: Option<Vec<String>>,
     /// When the zone was created
+    #[serde(with = "time::serde::rfc3339")]
     pub created_on: OffsetDateTime,
     /// Exists only with a deactivated status and indicates the reason the zone is not resolving on
     /// the Cloudflare network.
@@ -160,6 +161,7 @@ pub struct Zone {
     /// Metadata about the domain.
     pub meta: Meta,
     /// When the zone was last modified
+    #[serde(with = "time::serde::rfc3339")]
     pub modified_on: OffsetDateTime,
     /// Cloudflare-assigned name servers. This is only populated for zones that use Cloudflare DNS
     pub name_servers: Vec<String>,

--- a/cloudflare/src/endpoints/zone.rs
+++ b/cloudflare/src/endpoints/zone.rs
@@ -4,8 +4,7 @@ use crate::framework::{
     response::ApiResult,
 };
 use crate::framework::{OrderDirection, SearchMatch};
-use chrono::offset::Utc;
-use chrono::DateTime;
+use time::OffsetDateTime;
 
 /// List Zones
 /// List, search, sort, and filter your zones
@@ -148,7 +147,7 @@ pub struct Zone {
     /// A list of beta features in which the zone is participating
     pub betas: Option<Vec<String>>,
     /// When the zone was created
-    pub created_on: DateTime<Utc>,
+    pub created_on: OffsetDateTime,
     /// Exists only with a deactivated status and indicates the reason the zone is not resolving on
     /// the Cloudflare network.
     pub deactivation_reason: Option<String>,
@@ -161,7 +160,7 @@ pub struct Zone {
     /// Metadata about the domain.
     pub meta: Meta,
     /// When the zone was last modified
-    pub modified_on: DateTime<Utc>,
+    pub modified_on: OffsetDateTime,
     /// Cloudflare-assigned name servers. This is only populated for zones that use Cloudflare DNS
     pub name_servers: Vec<String>,
     /// DNS host at the time of switching to Cloudflare

--- a/cloudflare/src/lib.rs
+++ b/cloudflare/src/lib.rs
@@ -1,5 +1,4 @@
 ///! An API client for the [Cloudflare API](https://api.cloudflare.com)
-extern crate chrono;
 extern crate reqwest;
 #[macro_use]
 extern crate serde;


### PR DESCRIPTION
This is a semver breaking change because the `chrono` types are currently publicly exposed in structs.