### PR TITLE
Remove unnecessary cfg-if dep

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = "1.0"
 async-trait = "0.1"
 base64 = "0.13"
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock", "std", "wasmbind"] }
-cfg-if = "1.0"
 http = "0.2"
 percent-encoding = "2.1.0"
 reqwest = { version = "0.11.4", default-features = false, features = ["json", "blocking"] }


### PR DESCRIPTION
`cfg-if` without a corresponding `else` isn't needed and just makes the build take longer. Let's get rid of it.