### PR TITLE
Make blocking API an optional feature

### DIFF
--- a/cloudflare-examples/Cargo.toml
+++ b/cloudflare-examples/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.1.4", features = ["env"] }
-cloudflare = {path = "../cloudflare"}
+cloudflare = { path = "../cloudflare", features = ["blocking"] }
 maplit = "1.0"
 serde = { version = "1.0" }
 serde_json = "1.0"

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -12,13 +12,14 @@ license = "BSD-3-Clause"
 default = ["default-tls"]
 default-tls = ["reqwest/default-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+blocking = ["reqwest/blocking"]
 
 [dependencies]
 async-trait = "0.1"
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock", "std", "wasmbind"] }
 http = "0.2"
 percent-encoding = "2.1.0"
-reqwest = { version = "0.11.4", default-features = false, features = ["json", "blocking"] }
+reqwest = { version = "0.11.4", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "2.0", features = ["base64"] }

--- a/cloudflare/src/framework/mod.rs
+++ b/cloudflare/src/framework/mod.rs
@@ -4,7 +4,8 @@ This module controls how requests are sent to Cloudflare's API, and how response
 pub mod apiclient;
 pub mod async_api;
 pub mod auth;
-#[cfg(not(target_arch = "wasm32"))] // There is no blocking implementation for wasm.
+// There is no blocking implementation for wasm.
+#[cfg(all(feature = "blocking", not(target_arch = "wasm32")))]
 pub mod blocking_api;
 pub mod endpoint;
 #[cfg(not(target_arch = "wasm32"))] // The mock contains a blocking implementation.
@@ -61,7 +62,7 @@ impl<'a> From<&'a Environment> for url::Url {
 }
 
 // There is no blocking support for wasm.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "blocking", not(target_arch = "wasm32")))]
 /// Synchronous Cloudflare API client.
 pub struct HttpApiClient {
     environment: Environment,

--- a/cloudflare/src/framework/response/mod.rs
+++ b/cloudflare/src/framework/response/mod.rs
@@ -42,7 +42,7 @@ pub fn map_api_response<ResultType: ApiResult>(
 /// Some endpoints return nothing. That's OK.
 impl ApiResult for () {}
 
-#[cfg(test)]
+#[cfg(all(test, feature = "blocking", not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use std::collections::HashMap;

--- a/cloudflare/src/framework/response/mod.rs
+++ b/cloudflare/src/framework/response/mod.rs
@@ -18,7 +18,7 @@ pub struct ApiSuccess<ResultType> {
 pub type ApiResponse<ResultType> = Result<ApiSuccess<ResultType>, ApiFailure>;
 
 // There is no blocking implementation for wasm.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "blocking", not(target_arch = "wasm32")))]
 // If the response is 200 and parses, return Success.
 // If the response is 200 and doesn't parse, return Invalid.
 // If the response isn't 200, return Failure, with API errors if they were included.


### PR DESCRIPTION
This may not seem like a huge deal given that users need to build `tokio` anyway to use the library. But `blocking` is optional in `reqwest` because it adds to the list of required features for `tokio`, and so we should make it optional for consumers as well.