### PR TITLE
Cleanups

### DIFF
--- a/cloudflare-e2e-test/Cargo.toml
+++ b/cloudflare-e2e-test/Cargo.toml
@@ -3,13 +3,14 @@ name = "cloudflare-e2e-test"
 version = "0.5.0"
 edition = "2018"
 description = "End-to-end tests of the Cloudflare Rust API client"
+license = "BSD-3-Clause"
 
 [[bin]]
 name = "cloudflare-e2e-test"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.1", features = ["env"] }
-cloudflare = {path = "../cloudflare"}
 anyhow = "1.0.33"
-tokio = { version = "1", features = ["macros"] }
+clap = { version = "4.1", features = ["env"] }
+cloudflare = { path = "../cloudflare" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/cloudflare-examples/Cargo.toml
+++ b/cloudflare-examples/Cargo.toml
@@ -3,6 +3,7 @@ name = "cloudflare-examples"
 version = "0.5.0"
 edition = "2018"
 description = "Examples of how to use the Cloudflare Rust API client"
+license = "BSD-3-Clause"
 
 [[bin]]
 name = "cloudflare-examples"

--- a/cloudflare-examples/Cargo.toml
+++ b/cloudflare-examples/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.5.0"
 edition = "2018"
 description = "Examples of how to use the Cloudflare Rust API client"
 license = "BSD-3-Clause"
+rust-version = "1.56.0"
 
 [[bin]]
 name = "cloudflare-examples"
@@ -12,6 +13,5 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.1.4", features = ["env"] }
 cloudflare = { path = "../cloudflare", features = ["blocking"] }
-maplit = "1.0"
 serde = { version = "1.0" }
 serde_json = "1.0"

--- a/cloudflare-examples/src/main.rs
+++ b/cloudflare-examples/src/main.rs
@@ -1,8 +1,3 @@
-#[macro_use]
-extern crate maplit;
-extern crate clap;
-extern crate cloudflare;
-
 use clap::{Arg, ArgMatches, Command};
 use cloudflare::endpoints::{account, dns, workers, zone};
 use cloudflare::framework::{
@@ -12,6 +7,7 @@ use cloudflare::framework::{
     response::{ApiFailure, ApiResponse, ApiResult},
     Environment, HttpApiClient, HttpApiClientConfig, OrderDirection,
 };
+use maplit::hashmap;
 use serde::Serialize;
 
 type SectionFunction<ApiClientType> = fn(&ArgMatches, &ApiClientType);
@@ -288,12 +284,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let key = matches.remove_one("auth-key");
     let token = matches.remove_one("auth-token");
 
-    let matched_sections =
-        sections
-            .iter()
-            .filter(|&(section_name, _): &(&&str, &Section<HttpApiClient>)| {
-                matches.subcommand_matches(section_name).is_some()
-            });
+    let matched_sections = sections.iter().filter(
+        |&(section_name, _): &(&&str, &Section<'_, HttpApiClient>)| {
+            matches.subcommand_matches(section_name).is_some()
+        },
+    );
 
     let credentials: Credentials = if let Some(key) = key {
         Credentials::UserAuthKey { email, key }

--- a/cloudflare-examples/src/main.rs
+++ b/cloudflare-examples/src/main.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use clap::{Arg, ArgMatches, Command};
 use cloudflare::endpoints::{account, dns, workers, zone};
 use cloudflare::framework::{
@@ -7,7 +9,6 @@ use cloudflare::framework::{
     response::{ApiFailure, ApiResponse, ApiResult},
     Environment, HttpApiClient, HttpApiClientConfig, OrderDirection,
 };
-use maplit::hashmap;
 use serde::Serialize;
 
 type SectionFunction<ApiClientType> = fn(&ArgMatches, &ApiClientType);
@@ -194,61 +195,84 @@ fn mock_api<ApiClientType: ApiClient>(_args: &ArgMatches, _api: &ApiClientType) 
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let sections = hashmap! {
-        "zone" => Section{
-            args: vec![Arg::new("zone_identifier").required(true)],
-            description: "A Zone is a domain name along with its subdomains and other identities",
-            function: zone
-        },
-        "dns" => Section{
-            args: vec![Arg::new("zone_identifier").required(true)],
-            description: "DNS Records for a Zone",
-            function: dns
-        },
-        "create_txt_record" => Section{
-            args: vec![
-                Arg::new("zone_identifier").required(true),
-                Arg::new("name").required(true),
-                Arg::new("content").required(true),
+    let sections = HashMap::from([
+        (
+            "zone",
+            Section {
+                args: vec![Arg::new("zone_identifier").required(true)],
+                description:
+                    "A Zone is a domain name along with its subdomains and other identities",
+                function: zone,
+            },
+        ),
+        (
+            "dns",
+            Section {
+                args: vec![Arg::new("zone_identifier").required(true)],
+                description: "DNS Records for a Zone",
+                function: dns,
+            },
+        ),
+        (
+            "create_txt_record",
+            Section {
+                args: vec![
+                    Arg::new("zone_identifier").required(true),
+                    Arg::new("name").required(true),
+                    Arg::new("content").required(true),
                 ],
-            description: "Create a TXT record for a zone",
-            function: create_txt_record
-        },
-        "mock_api" => Section{
-            args: vec![],
-            description: "Run a mock API request",
-            function: mock_api
-        },
-        "list_routes" => Section{
-            args: vec![
-                Arg::new("zone_identifier").required(true),
-            ],
-            description: "Activate a Worker on a Route",
-            function: list_routes
-        },
-        "list_accounts" => Section{
-            args: vec![],
-            description: "List accounts",
-            function: list_accounts
-        },
-        "create_route" => Section{
-            args: vec![
-                Arg::new("zone_identifier").required(true),
-                Arg::new("route_pattern").required(true),
-                Arg::new("script_name").required(false),
-            ],
-            description: "Activate a Worker on a Route",
-            function: create_route
-        },
-        "delete_route" => Section{
-            args: vec![
-                Arg::new("zone_identifier").required(true),
-                Arg::new("route_identifier").required(true),
-            ],
-            description: "Activate a Worker on a Route",
-            function: delete_route
-        },
-    };
+                description: "Create a TXT record for a zone",
+                function: create_txt_record,
+            },
+        ),
+        (
+            "mock_api",
+            Section {
+                args: vec![],
+                description: "Run a mock API request",
+                function: mock_api,
+            },
+        ),
+        (
+            "list_routes",
+            Section {
+                args: vec![Arg::new("zone_identifier").required(true)],
+                description: "Activate a Worker on a Route",
+                function: list_routes,
+            },
+        ),
+        (
+            "list_accounts",
+            Section {
+                args: vec![],
+                description: "List accounts",
+                function: list_accounts,
+            },
+        ),
+        (
+            "create_route",
+            Section {
+                args: vec![
+                    Arg::new("zone_identifier").required(true),
+                    Arg::new("route_pattern").required(true),
+                    Arg::new("script_name").required(false),
+                ],
+                description: "Activate a Worker on a Route",
+                function: create_route,
+            },
+        ),
+        (
+            "delete_route",
+            Section {
+                args: vec![
+                    Arg::new("zone_identifier").required(true),
+                    Arg::new("route_identifier").required(true),
+                ],
+                description: "Activate a Worker on a Route",
+                function: delete_route,
+            },
+        ),
+    ]);
 
     let mut cli = Command::new("cloudflare-rust")
         .version("0.0")

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -10,13 +10,18 @@ license = "BSD-3-Clause"
 
 [features]
 default = ["default-tls"]
+blocking = ["reqwest/blocking"]
 default-tls = ["reqwest/default-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
-blocking = ["reqwest/blocking"]
 
 [dependencies]
 async-trait = "0.1"
-chrono = { version = "0.4", default-features = false, features = ["serde", "clock", "std", "wasmbind"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "clock",
+    "serde",
+    "std",
+    "wasmbind",
+] }
 http = "0.2"
 percent-encoding = "2.1.0"
 reqwest = { version = "0.11.4", default-features = false, features = ["json"] }

--- a/cloudflare/src/endpoints/account/list_accounts.rs
+++ b/cloudflare/src/endpoints/account/list_accounts.rs
@@ -3,6 +3,8 @@ use super::Account;
 use crate::framework::endpoint::{Endpoint, Method};
 use crate::framework::OrderDirection;
 
+use serde::Serialize;
+
 /// List Accounts
 /// List all accounts you have ownership or verified access to
 /// https://api.cloudflare.com/#accounts-list-accounts

--- a/cloudflare/src/endpoints/account/list_accounts.rs
+++ b/cloudflare/src/endpoints/account/list_accounts.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 
 /// List Accounts
 /// List all accounts you have ownership or verified access to
-/// https://api.cloudflare.com/#accounts-list-accounts
+/// <https://api.cloudflare.com/#accounts-list-accounts>
 #[derive(Debug)]
 pub struct ListAccounts {
     pub params: Option<ListAccountsParams>,

--- a/cloudflare/src/endpoints/account/mod.rs
+++ b/cloudflare/src/endpoints/account/mod.rs
@@ -1,6 +1,6 @@
 use crate::framework::response::ApiResult;
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 pub mod list_accounts;
 pub use list_accounts::ListAccounts;

--- a/cloudflare/src/endpoints/account/mod.rs
+++ b/cloudflare/src/endpoints/account/mod.rs
@@ -7,7 +7,7 @@ pub use list_accounts::ListAccounts;
 
 /// Cloudflare Accounts
 /// An Account is the root object which owns other resources such as zones, load balancers and billing details.
-/// https://api.cloudflare.com/#accounts-properties
+/// <https://api.cloudflare.com/#accounts-properties>
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Account {
     /// Account identifier tag.
@@ -30,7 +30,7 @@ pub struct Settings {
 
 /// Cloudflare Accounts Details
 /// An Account is the root object which owns other resources such as zones, load balancers and billing details.
-/// https://api.cloudflare.com/#accounts-properties
+/// <https://api.cloudflare.com/#accounts-properties>
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct AccountDetails {
     /// Account identifier tag.

--- a/cloudflare/src/endpoints/argo_tunnel/create_tunnel.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/create_tunnel.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use serde_with::{
     base64::{Base64, Standard},
     formats::Padded,

--- a/cloudflare/src/endpoints/argo_tunnel/create_tunnel.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/create_tunnel.rs
@@ -12,7 +12,7 @@ use super::Tunnel;
 /// Create a Named Argo Tunnel
 /// This creates the Tunnel, which can then be routed and ran. Creating the Tunnel per se is only
 /// a metadata operation (i.e. no Tunnel is running at this point).
-/// https://api.cloudflare.com/#argo-tunnel-create-argo-tunnel
+/// <https://api.cloudflare.com/#argo-tunnel-create-argo-tunnel>
 #[derive(Debug)]
 pub struct CreateTunnel<'a> {
     pub account_identifier: &'a str,

--- a/cloudflare/src/endpoints/argo_tunnel/data_structures.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/data_structures.rs
@@ -6,7 +6,7 @@ use crate::framework::response::ApiResult;
 
 /// A Named Argo Tunnel
 /// This is an Argo Tunnel that has been created. It can be used for routing and subsequent running.
-/// https://api.cloudflare.com/#argo-tunnel-properties
+/// <https://api.cloudflare.com/#argo-tunnel-properties>
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Tunnel {
     pub id: Uuid,
@@ -18,7 +18,7 @@ pub struct Tunnel {
 }
 
 /// An active connection for a Named Argo Tunnel.
-/// https://api.cloudflare.com/#argo-tunnel-properties
+/// <https://api.cloudflare.com/#argo-tunnel-properties>
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct ActiveConnection {
     pub colo_name: String,

--- a/cloudflare/src/endpoints/argo_tunnel/data_structures.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/data_structures.rs
@@ -1,4 +1,5 @@
 use chrono::{offset::Utc, DateTime};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::framework::response::ApiResult;

--- a/cloudflare/src/endpoints/argo_tunnel/delete_tunnel.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/delete_tunnel.rs
@@ -3,7 +3,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 use super::Tunnel;
 
 /// Delete a tunnel
-/// https://api.cloudflare.com/#argo-tunnel-delete-argo-tunnel
+/// <https://api.cloudflare.com/#argo-tunnel-delete-argo-tunnel>
 #[derive(Debug)]
 pub struct DeleteTunnel<'a> {
     pub account_identifier: &'a str,

--- a/cloudflare/src/endpoints/argo_tunnel/list_tunnels.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/list_tunnels.rs
@@ -6,7 +6,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 use super::Tunnel;
 
 /// List/search tunnels in an account.
-/// https://api.cloudflare.com/#argo-tunnel-list-argo-tunnels
+/// <https://api.cloudflare.com/#argo-tunnel-list-argo-tunnels>
 #[derive(Debug)]
 pub struct ListTunnels<'a> {
     pub account_identifier: &'a str,

--- a/cloudflare/src/endpoints/argo_tunnel/list_tunnels.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/list_tunnels.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use serde::Serialize;
 
 use crate::framework::endpoint::{Endpoint, Method};
 

--- a/cloudflare/src/endpoints/argo_tunnel/route_dns.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/route_dns.rs
@@ -1,6 +1,7 @@
 use crate::framework::endpoint::{Endpoint, Method};
 
 use super::RouteResult;
+use serde::Serialize;
 use uuid::Uuid;
 
 /// Route for a Named Argo Tunnel

--- a/cloudflare/src/endpoints/dns.rs
+++ b/cloudflare/src/endpoints/dns.rs
@@ -6,6 +6,7 @@ use crate::framework::{
 use crate::framework::{OrderDirection, SearchMatch};
 use chrono::offset::Utc;
 use chrono::DateTime;
+use serde::{Deserialize, Serialize};
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 /// List DNS Records

--- a/cloudflare/src/endpoints/dns.rs
+++ b/cloudflare/src/endpoints/dns.rs
@@ -2,7 +2,7 @@ use crate::framework::{
     endpoint::{Endpoint, Method},
     response::ApiResult,
 };
-/// https://api.cloudflare.com/#dns-records-for-a-zone-properties
+/// <https://api.cloudflare.com/#dns-records-for-a-zone-properties>
 use crate::framework::{OrderDirection, SearchMatch};
 use chrono::offset::Utc;
 use chrono::DateTime;
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 /// List DNS Records
-/// https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records
+/// <https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records>
 #[derive(Debug)]
 pub struct ListDnsRecords<'a> {
     pub zone_identifier: &'a str,
@@ -29,7 +29,7 @@ impl<'a> Endpoint<Vec<DnsRecord>, ListDnsRecordsParams> for ListDnsRecords<'a> {
 }
 
 /// Create DNS Record
-/// https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
+/// <https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record>
 #[derive(Debug)]
 pub struct CreateDnsRecord<'a> {
     pub zone_identifier: &'a str,
@@ -66,7 +66,7 @@ pub struct CreateDnsRecordParams<'a> {
 }
 
 /// Delete DNS Record
-/// https://api.cloudflare.com/#dns-records-for-a-zone-delete-dns-record
+/// <https://api.cloudflare.com/#dns-records-for-a-zone-delete-dns-record>
 #[derive(Debug)]
 pub struct DeleteDnsRecord<'a> {
     pub zone_identifier: &'a str,
@@ -85,7 +85,7 @@ impl<'a> Endpoint<DeleteDnsRecordResponse> for DeleteDnsRecord<'a> {
 }
 
 /// Update DNS Record
-/// https://api.cloudflare.com/#dns-records-for-a-zone-update-dns-record
+/// <https://api.cloudflare.com/#dns-records-for-a-zone-update-dns-record>
 #[derive(Debug)]
 pub struct UpdateDnsRecord<'a> {
     pub zone_identifier: &'a str,

--- a/cloudflare/src/endpoints/load_balancing/create_lb.rs
+++ b/cloudflare/src/endpoints/load_balancing/create_lb.rs
@@ -4,6 +4,8 @@ use crate::endpoints::load_balancing::{
 };
 use crate::framework::endpoint::{Endpoint, Method};
 
+use serde::Serialize;
+
 /// Create Load Balancer
 /// https://api.cloudflare.com/#load-balancers-create-load-balancer
 #[derive(Debug)]

--- a/cloudflare/src/endpoints/load_balancing/create_lb.rs
+++ b/cloudflare/src/endpoints/load_balancing/create_lb.rs
@@ -7,7 +7,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 use serde::Serialize;
 
 /// Create Load Balancer
-/// https://api.cloudflare.com/#load-balancers-create-load-balancer
+/// <https://api.cloudflare.com/#load-balancers-create-load-balancer>
 #[derive(Debug)]
 pub struct CreateLoadBalancer<'a> {
     /// The Zone to which this Load Balancer shall belong.

--- a/cloudflare/src/endpoints/load_balancing/create_pool.rs
+++ b/cloudflare/src/endpoints/load_balancing/create_pool.rs
@@ -4,7 +4,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 use serde::Serialize;
 
 /// Create Pool
-/// https://api.cloudflare.com/#account-load-balancer-pools-create-pool
+/// <https://api.cloudflare.com/#account-load-balancer-pools-create-pool>
 #[derive(Debug)]
 pub struct CreatePool<'a> {
     /// The Cloudflare account to create this Pool under.

--- a/cloudflare/src/endpoints/load_balancing/create_pool.rs
+++ b/cloudflare/src/endpoints/load_balancing/create_pool.rs
@@ -1,6 +1,8 @@
 use crate::endpoints::load_balancing::{Origin, Pool};
 use crate::framework::endpoint::{Endpoint, Method};
 
+use serde::Serialize;
+
 /// Create Pool
 /// https://api.cloudflare.com/#account-load-balancer-pools-create-pool
 #[derive(Debug)]

--- a/cloudflare/src/endpoints/load_balancing/delete_lb.rs
+++ b/cloudflare/src/endpoints/load_balancing/delete_lb.rs
@@ -4,7 +4,7 @@ use crate::framework::response::ApiResult;
 use serde::Deserialize;
 
 /// Delete Load Balancer
-/// https://api.cloudflare.com/#load-balancers-delete-load-balancer
+/// <https://api.cloudflare.com/#load-balancers-delete-load-balancer>
 #[derive(Debug)]
 pub struct DeleteLoadBalancer<'a> {
     /// The Zone to which this Load Balancer belongs.

--- a/cloudflare/src/endpoints/load_balancing/delete_lb.rs
+++ b/cloudflare/src/endpoints/load_balancing/delete_lb.rs
@@ -1,6 +1,8 @@
 use crate::framework::endpoint::{Endpoint, Method};
 use crate::framework::response::ApiResult;
 
+use serde::Deserialize;
+
 /// Delete Load Balancer
 /// https://api.cloudflare.com/#load-balancers-delete-load-balancer
 #[derive(Debug)]

--- a/cloudflare/src/endpoints/load_balancing/delete_pool.rs
+++ b/cloudflare/src/endpoints/load_balancing/delete_pool.rs
@@ -4,7 +4,7 @@ use crate::framework::response::ApiResult;
 use serde::Deserialize;
 
 /// Delete Pool
-/// https://api.cloudflare.com/#account-load-balancer-pools-delete-pool
+/// <https://api.cloudflare.com/#account-load-balancer-pools-delete-pool>
 #[derive(Debug)]
 pub struct DeletePool<'a> {
     /// The Cloudflare account of this pool.

--- a/cloudflare/src/endpoints/load_balancing/delete_pool.rs
+++ b/cloudflare/src/endpoints/load_balancing/delete_pool.rs
@@ -1,6 +1,8 @@
 use crate::framework::endpoint::{Endpoint, Method};
 use crate::framework::response::ApiResult;
 
+use serde::Deserialize;
+
 /// Delete Pool
 /// https://api.cloudflare.com/#account-load-balancer-pools-delete-pool
 #[derive(Debug)]

--- a/cloudflare/src/endpoints/load_balancing/list_lb.rs
+++ b/cloudflare/src/endpoints/load_balancing/list_lb.rs
@@ -3,7 +3,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 use crate::framework::response::ApiResult;
 
 /// List Load Balancers
-/// https://api.cloudflare.com/#load-balancers-list-load-balancers
+/// <https://api.cloudflare.com/#load-balancers-list-load-balancers>
 #[derive(Debug)]
 pub struct ListLoadBalancers<'a> {
     /// The Zone to list Load Balancers from.

--- a/cloudflare/src/endpoints/load_balancing/mod.rs
+++ b/cloudflare/src/endpoints/load_balancing/mod.rs
@@ -8,6 +8,7 @@ pub mod pool_details;
 use crate::framework::response::ApiResult;
 use chrono::offset::Utc;
 use chrono::DateTime;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::net::IpAddr;

--- a/cloudflare/src/endpoints/load_balancing/pool_details.rs
+++ b/cloudflare/src/endpoints/load_balancing/pool_details.rs
@@ -2,7 +2,7 @@ use crate::endpoints::load_balancing::Pool;
 use crate::framework::endpoint::{Endpoint, Method};
 
 /// Pool Details
-/// https://api.cloudflare.com/#account-load-balancer-pools-pool-details
+/// <https://api.cloudflare.com/#account-load-balancer-pools-pool-details>
 #[derive(Debug)]
 pub struct PoolDetails<'a> {
     /// The Cloudflare account of this pool.

--- a/cloudflare/src/endpoints/plan.rs
+++ b/cloudflare/src/endpoints/plan.rs
@@ -1,3 +1,5 @@
+use serde::Deserialize;
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 /// Free plans won't have a Frequency, so most responses should accept Option instead.

--- a/cloudflare/src/endpoints/r2.rs
+++ b/cloudflare/src/endpoints/r2.rs
@@ -1,6 +1,6 @@
 use chrono::offset::Utc;
 use chrono::DateTime;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::framework::endpoint::{Endpoint, Method};

--- a/cloudflare/src/endpoints/user.rs
+++ b/cloudflare/src/endpoints/user.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 /// Get User Details
 /// Gets information about a user
-/// https://api.cloudflare.com/#user-user-details
+/// <https://api.cloudflare.com/#user-user-details>
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct Organization {
@@ -79,7 +79,7 @@ impl Endpoint<UserDetails, (), ()> for GetUserDetails {
 
 /// Validate User Token
 /// Returns whether a given token is valid or not.
-/// https://blog.cloudflare.com/api-tokens-general-availability/
+/// <https://blog.cloudflare.com/api-tokens-general-availability/>
 ///
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct UserTokenStatus {

--- a/cloudflare/src/endpoints/user.rs
+++ b/cloudflare/src/endpoints/user.rs
@@ -2,6 +2,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 use crate::framework::response::ApiResult;
 
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 /// Get User Details
 /// Gets information about a user

--- a/cloudflare/src/endpoints/workers/create_route.rs
+++ b/cloudflare/src/endpoints/workers/create_route.rs
@@ -2,6 +2,8 @@ use super::WorkersRouteIdOnly;
 
 use crate::framework::endpoint::{Endpoint, Method};
 
+use serde::Serialize;
+
 /// Create a Route
 /// Creates a route mapping the given pattern to the given script
 /// https://api.cloudflare.com/#worker-routes-create-route

--- a/cloudflare/src/endpoints/workers/create_route.rs
+++ b/cloudflare/src/endpoints/workers/create_route.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 /// Create a Route
 /// Creates a route mapping the given pattern to the given script
-/// https://api.cloudflare.com/#worker-routes-create-route
+/// <https://api.cloudflare.com/#worker-routes-create-route>
 #[derive(Debug)]
 pub struct CreateRoute<'a> {
     pub zone_identifier: &'a str,

--- a/cloudflare/src/endpoints/workers/create_secret.rs
+++ b/cloudflare/src/endpoints/workers/create_secret.rs
@@ -2,6 +2,8 @@ use super::WorkersSecret;
 
 use crate::framework::endpoint::{Endpoint, Method};
 
+use serde::Serialize;
+
 /// Create Secret
 /// https://api.cloudflare.com/#worker-create-secret
 #[derive(Debug)]

--- a/cloudflare/src/endpoints/workers/create_secret.rs
+++ b/cloudflare/src/endpoints/workers/create_secret.rs
@@ -5,7 +5,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 use serde::Serialize;
 
 /// Create Secret
-/// https://api.cloudflare.com/#worker-create-secret
+/// <https://api.cloudflare.com/#worker-create-secret>
 #[derive(Debug)]
 pub struct CreateSecret<'a> {
     /// Account ID of script owner

--- a/cloudflare/src/endpoints/workers/create_tail.rs
+++ b/cloudflare/src/endpoints/workers/create_tail.rs
@@ -5,7 +5,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 use serde::Serialize;
 
 /// Create Tail
-/// https://api.cloudflare.com/#worker-create-tail
+/// <https://api.cloudflare.com/#worker-create-tail>
 #[derive(Debug)]
 pub struct CreateTail<'a> {
     /// Account ID of owner of the script

--- a/cloudflare/src/endpoints/workers/create_tail.rs
+++ b/cloudflare/src/endpoints/workers/create_tail.rs
@@ -2,6 +2,8 @@ use super::WorkersTail;
 
 use crate::framework::endpoint::{Endpoint, Method};
 
+use serde::Serialize;
+
 /// Create Tail
 /// https://api.cloudflare.com/#worker-create-tail
 #[derive(Debug)]

--- a/cloudflare/src/endpoints/workers/delete_route.rs
+++ b/cloudflare/src/endpoints/workers/delete_route.rs
@@ -4,7 +4,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 
 /// Delete a Route
 /// Deletes a route by route id
-/// https://api.cloudflare.com/#worker-routes-delete-route
+/// <https://api.cloudflare.com/#worker-routes-delete-route>
 #[derive(Debug)]
 pub struct DeleteRoute<'a> {
     pub zone_identifier: &'a str,

--- a/cloudflare/src/endpoints/workers/delete_script.rs
+++ b/cloudflare/src/endpoints/workers/delete_script.rs
@@ -1,6 +1,8 @@
 use crate::framework::endpoint::{Endpoint, Method};
 use crate::framework::response::ApiResult;
 
+use serde::{Deserialize, Serialize};
+
 /// Delete Workers script
 /// https://api.cloudflare.com/#worker-script-delete-worker
 #[derive(Debug)]

--- a/cloudflare/src/endpoints/workers/delete_script.rs
+++ b/cloudflare/src/endpoints/workers/delete_script.rs
@@ -4,7 +4,7 @@ use crate::framework::response::ApiResult;
 use serde::{Deserialize, Serialize};
 
 /// Delete Workers script
-/// https://api.cloudflare.com/#worker-script-delete-worker
+/// <https://api.cloudflare.com/#worker-script-delete-worker>
 #[derive(Debug)]
 pub struct DeleteScript<'a> {
     /// account id of owner of the script

--- a/cloudflare/src/endpoints/workers/delete_secret.rs
+++ b/cloudflare/src/endpoints/workers/delete_secret.rs
@@ -1,7 +1,7 @@
 use crate::framework::endpoint::{Endpoint, Method};
 
 /// Delete Secret
-/// https://api.cloudflare.com/#worker-delete-secret
+/// <https://api.cloudflare.com/#worker-delete-secret>
 #[derive(Debug)]
 pub struct DeleteSecret<'a> {
     /// account id of owner of the script

--- a/cloudflare/src/endpoints/workers/delete_tail.rs
+++ b/cloudflare/src/endpoints/workers/delete_tail.rs
@@ -1,7 +1,7 @@
 use crate::framework::endpoint::{Endpoint, Method};
 
 /// Delete Tail
-/// https://api.cloudflare.com/#worker-delete-tail
+/// <https://api.cloudflare.com/#worker-delete-tail>
 #[derive(Debug)]
 pub struct DeleteTail<'a> {
     /// Account id of owner of the script

--- a/cloudflare/src/endpoints/workers/list_routes.rs
+++ b/cloudflare/src/endpoints/workers/list_routes.rs
@@ -4,7 +4,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 
 /// List Routes
 /// Lists all route mappings for a given zone
-/// https://api.cloudflare.com/#worker-routes-list-routes
+/// <https://api.cloudflare.com/#worker-routes-list-routes>
 #[derive(Debug)]
 pub struct ListRoutes<'a> {
     pub zone_identifier: &'a str,

--- a/cloudflare/src/endpoints/workers/list_secrets.rs
+++ b/cloudflare/src/endpoints/workers/list_secrets.rs
@@ -4,7 +4,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 
 /// List Secrets
 /// Lists all secrets mappings for a given script
-/// https://api.cloudflare.com/#worker-secrets-list-secrets
+/// <https://api.cloudflare.com/#worker-secrets-list-secrets>
 #[derive(Debug)]
 pub struct ListSecrets<'a> {
     pub account_identifier: &'a str,

--- a/cloudflare/src/endpoints/workers/list_tails.rs
+++ b/cloudflare/src/endpoints/workers/list_tails.rs
@@ -4,7 +4,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 
 /// List Tails
 /// Lists all active Tail sessions for a given Worker
-/// https://api.cloudflare.com/#worker-tails-list-tails
+/// <https://api.cloudflare.com/#worker-tails-list-tails>
 #[derive(Debug)]
 pub struct ListTails<'a> {
     pub account_identifier: &'a str,

--- a/cloudflare/src/endpoints/workers/mod.rs
+++ b/cloudflare/src/endpoints/workers/mod.rs
@@ -1,7 +1,7 @@
 use crate::framework::response::ApiResult;
 
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 mod create_route;
 mod create_secret;

--- a/cloudflare/src/endpoints/workers/mod.rs
+++ b/cloudflare/src/endpoints/workers/mod.rs
@@ -33,7 +33,7 @@ pub use send_tail_heartbeat::SendTailHeartbeat;
 
 /// Workers KV Route
 /// Routes are basic patterns used to enable or disable workers that match requests.
-/// https://api.cloudflare.com/#worker-routes-properties
+/// <https://api.cloudflare.com/#worker-routes-properties>
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct WorkersRoute {
     /// Namespace identifier tag.
@@ -60,7 +60,7 @@ pub struct WorkersRouteIdOnly {
 impl ApiResult for WorkersRouteIdOnly {}
 
 /// Secrets attach to a single script to be readable in only the script
-/// https://api.cloudflare.com/#worker-secrets-properties
+/// <https://api.cloudflare.com/#worker-secrets-properties>
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct WorkersSecret {
     pub name: String,
@@ -72,7 +72,7 @@ impl ApiResult for WorkersSecret {}
 impl ApiResult for Vec<WorkersSecret> {} // to parse arrays too
 
 /// A Tail is attached to a single Worker and is impermanent
-/// https://api.cloudflare.com/#worker-tail-properties
+/// <https://api.cloudflare.com/#worker-tail-properties>
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct WorkersTail {
     pub id: String,

--- a/cloudflare/src/endpoints/workers/send_tail_heartbeat.rs
+++ b/cloudflare/src/endpoints/workers/send_tail_heartbeat.rs
@@ -3,7 +3,7 @@ use super::WorkersTail;
 use crate::framework::endpoint::{Endpoint, Method};
 
 /// Send Tail Heartbeat
-/// https://api.cloudflare.com/#worker-tail-heartbeat
+/// <https://api.cloudflare.com/#worker-tail-heartbeat>
 #[derive(Debug)]
 pub struct SendTailHeartbeat<'a> {
     /// Account ID of owner of the script

--- a/cloudflare/src/endpoints/workerskv/create_namespace.rs
+++ b/cloudflare/src/endpoints/workerskv/create_namespace.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 /// Creates a namespace under the given title.
 /// A 400 is returned if the account already owns a namespace with this title.
 /// A namespace must be explicitly deleted to be replaced.
-/// https://api.cloudflare.com/#workers-kv-namespace-create-a-namespace
+/// <https://api.cloudflare.com/#workers-kv-namespace-create-a-namespace>
 #[derive(Debug)]
 pub struct CreateNamespace<'a> {
     pub account_identifier: &'a str,

--- a/cloudflare/src/endpoints/workerskv/create_namespace.rs
+++ b/cloudflare/src/endpoints/workerskv/create_namespace.rs
@@ -2,6 +2,8 @@ use super::WorkersKvNamespace;
 
 use crate::framework::endpoint::{Endpoint, Method};
 
+use serde::Serialize;
+
 /// Create a Namespace
 /// Creates a namespace under the given title.
 /// A 400 is returned if the account already owns a namespace with this title.

--- a/cloudflare/src/endpoints/workerskv/delete_bulk.rs
+++ b/cloudflare/src/endpoints/workerskv/delete_bulk.rs
@@ -3,7 +3,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 /// Delete Key-Value Pairs in Bulk
 /// Deletes multiple key-value pairs from Workers KV at once.
 /// A 404 is returned if a delete action is for a namespace ID the account doesn't have.
-/// https://api.cloudflare.com/#workers-kv-namespace-delete-multiple-key-value-pairs
+/// <https://api.cloudflare.com/#workers-kv-namespace-delete-multiple-key-value-pairs>
 #[derive(Debug)]
 pub struct DeleteBulk<'a> {
     pub account_identifier: &'a str,

--- a/cloudflare/src/endpoints/workerskv/delete_key.rs
+++ b/cloudflare/src/endpoints/workerskv/delete_key.rs
@@ -3,7 +3,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 /// Delete a key-value pair from Workers KV
 /// Deletes a given key from the given namespace in Workers KV.
 /// Returns 404 if the given namespace id is not found for an account.
-/// https://api.cloudflare.com/#workers-kv-namespace-delete-key-value-pair
+/// <https://api.cloudflare.com/#workers-kv-namespace-delete-key-value-pair>
 #[derive(Debug)]
 pub struct DeleteKey<'a> {
     pub account_identifier: &'a str,

--- a/cloudflare/src/endpoints/workerskv/list_namespace_keys.rs
+++ b/cloudflare/src/endpoints/workerskv/list_namespace_keys.rs
@@ -2,6 +2,8 @@ use super::Key;
 
 use crate::framework::endpoint::{Endpoint, Method};
 
+use serde::Serialize;
+
 /// List a Namespace's Keys
 /// https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys
 #[derive(Debug)]

--- a/cloudflare/src/endpoints/workerskv/list_namespace_keys.rs
+++ b/cloudflare/src/endpoints/workerskv/list_namespace_keys.rs
@@ -5,7 +5,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 use serde::Serialize;
 
 /// List a Namespace's Keys
-/// https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys
+/// <https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys>
 #[derive(Debug)]
 pub struct ListNamespaceKeys<'a> {
     pub account_identifier: &'a str,

--- a/cloudflare/src/endpoints/workerskv/list_namespaces.rs
+++ b/cloudflare/src/endpoints/workerskv/list_namespaces.rs
@@ -2,6 +2,8 @@ use super::WorkersKvNamespace;
 
 use crate::framework::endpoint::{Endpoint, Method};
 
+use serde::Serialize;
+
 /// List Namespaces
 /// Returns the namespaces owned by an account
 /// https://api.cloudflare.com/#workers-kv-namespace-list-namespaces

--- a/cloudflare/src/endpoints/workerskv/list_namespaces.rs
+++ b/cloudflare/src/endpoints/workerskv/list_namespaces.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 /// List Namespaces
 /// Returns the namespaces owned by an account
-/// https://api.cloudflare.com/#workers-kv-namespace-list-namespaces
+/// <https://api.cloudflare.com/#workers-kv-namespace-list-namespaces>
 #[derive(Debug)]
 pub struct ListNamespaces<'a> {
     pub account_identifier: &'a str,

--- a/cloudflare/src/endpoints/workerskv/mod.rs
+++ b/cloudflare/src/endpoints/workerskv/mod.rs
@@ -2,7 +2,7 @@ use crate::framework::response::ApiResult;
 use chrono::DateTime;
 use chrono::{TimeZone, Utc};
 use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 
 pub mod create_namespace;
 pub mod delete_bulk;

--- a/cloudflare/src/endpoints/workerskv/mod.rs
+++ b/cloudflare/src/endpoints/workerskv/mod.rs
@@ -40,7 +40,7 @@ const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
 
 /// Workers KV Namespace
 /// A Namespace is a collection of key-value pairs stored in Workers KV.
-/// https://api.cloudflare.com/#workers-kv-namespace-properties
+/// <https://api.cloudflare.com/#workers-kv-namespace-properties>
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct WorkersKvNamespace {
     /// Namespace identifier tag.

--- a/cloudflare/src/endpoints/workerskv/remove_namespace.rs
+++ b/cloudflare/src/endpoints/workerskv/remove_namespace.rs
@@ -2,7 +2,7 @@ use crate::framework::endpoint::{Endpoint, Method};
 
 /// Remove a Namespace
 /// Deletes the namespace corresponding to the given ID.
-/// https://api.cloudflare.com/#workers-kv-namespace-remove-a-namespace
+/// <https://api.cloudflare.com/#workers-kv-namespace-remove-a-namespace>
 #[derive(Debug)]
 pub struct RemoveNamespace<'a> {
     pub account_identifier: &'a str,

--- a/cloudflare/src/endpoints/workerskv/rename_namespace.rs
+++ b/cloudflare/src/endpoints/workerskv/rename_namespace.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 /// Rename a Namespace
 /// Modifies a namespace's title.
-/// https://api.cloudflare.com/#workers-kv-namespace-rename-a-namespace
+/// <https://api.cloudflare.com/#workers-kv-namespace-rename-a-namespace>
 #[derive(Debug)]
 pub struct RenameNamespace<'a> {
     pub account_identifier: &'a str,

--- a/cloudflare/src/endpoints/workerskv/rename_namespace.rs
+++ b/cloudflare/src/endpoints/workerskv/rename_namespace.rs
@@ -1,5 +1,7 @@
 use crate::framework::endpoint::{Endpoint, Method};
 
+use serde::Serialize;
+
 /// Rename a Namespace
 /// Modifies a namespace's title.
 /// https://api.cloudflare.com/#workers-kv-namespace-rename-a-namespace

--- a/cloudflare/src/endpoints/workerskv/write_bulk.rs
+++ b/cloudflare/src/endpoints/workerskv/write_bulk.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Write Key-Value Pairs in Bulk
 /// Writes multiple key-value pairs to Workers KV at once.
 /// A 404 is returned if a write action is for a namespace ID the account doesn't have.
-/// https://api.cloudflare.com/#workers-kv-namespace-write-multiple-key-value-pairs
+/// <https://api.cloudflare.com/#workers-kv-namespace-write-multiple-key-value-pairs>
 #[derive(Debug)]
 pub struct WriteBulk<'a> {
     pub account_identifier: &'a str,

--- a/cloudflare/src/endpoints/workerskv/write_bulk.rs
+++ b/cloudflare/src/endpoints/workerskv/write_bulk.rs
@@ -1,5 +1,7 @@
 use crate::framework::endpoint::{Endpoint, Method};
 
+use serde::{Deserialize, Serialize};
+
 /// Write Key-Value Pairs in Bulk
 /// Writes multiple key-value pairs to Workers KV at once.
 /// A 404 is returned if a write action is for a namespace ID the account doesn't have.

--- a/cloudflare/src/endpoints/zone.rs
+++ b/cloudflare/src/endpoints/zone.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 /// List Zones
 /// List, search, sort, and filter your zones
-/// https://api.cloudflare.com/#zone-list-zones
+/// <https://api.cloudflare.com/#zone-list-zones>
 #[derive(Debug)]
 pub struct ListZones {
     pub params: ListZonesParams,
@@ -29,7 +29,7 @@ impl Endpoint<Vec<Zone>, ListZonesParams> for ListZones {
 }
 
 /// Zone Details
-/// https://api.cloudflare.com/#zone-zone-details
+/// <https://api.cloudflare.com/#zone-zone-details>
 #[derive(Debug)]
 pub struct ZoneDetails<'a> {
     pub identifier: &'a str,
@@ -44,7 +44,7 @@ impl<'a> Endpoint<Zone> for ZoneDetails<'a> {
 }
 
 /// Add Zone
-/// https://api.cloudflare.com/#zone-create-zone
+/// <https://api.cloudflare.com/#zone-create-zone>
 pub struct CreateZone<'a> {
     pub params: CreateZoneParams<'a>,
 }
@@ -137,7 +137,7 @@ pub struct Meta {
 }
 
 /// A Zone is a domain name along with its subdomains and other identities
-/// https://api.cloudflare.com/#zone-properties
+/// <https://api.cloudflare.com/#zone-properties>
 #[derive(Deserialize, Debug)]
 pub struct Zone {
     /// Zone identifier tag

--- a/cloudflare/src/endpoints/zone.rs
+++ b/cloudflare/src/endpoints/zone.rs
@@ -6,6 +6,7 @@ use crate::framework::{
 use crate::framework::{OrderDirection, SearchMatch};
 use chrono::offset::Utc;
 use chrono::DateTime;
+use serde::{Deserialize, Serialize};
 
 /// List Zones
 /// List, search, sort, and filter your zones

--- a/cloudflare/src/framework/mock.rs
+++ b/cloudflare/src/framework/mock.rs
@@ -3,6 +3,7 @@ use crate::framework::async_api;
 use crate::framework::endpoint::{Endpoint, Method};
 use crate::framework::response::{ApiError, ApiErrors, ApiFailure, ApiResponse, ApiResult};
 use async_trait::async_trait;
+use serde::Deserialize;
 use std::collections::HashMap;
 
 pub struct MockApiClient {}

--- a/cloudflare/src/framework/response/apifail.rs
+++ b/cloudflare/src/framework/response/apifail.rs
@@ -1,11 +1,9 @@
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::value::Value as JValue;
 use std::collections::HashMap;
 use std::error::Error;
+use std::fmt::{self, Debug, Write as _};
 
-use std::fmt;
-use std::fmt::Debug;
-use std::fmt::Write as _;
 /// Note that APIError's `eq` implementation only compares `code` and `message`.
 /// It does NOT compare the `other` values.
 #[derive(Deserialize, Debug)]
@@ -42,7 +40,7 @@ impl Eq for ApiErrors {}
 impl Error for ApiError {}
 
 impl fmt::Display for ApiError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Error {}: {}", self.code, self.message)
     }
 }
@@ -71,7 +69,7 @@ impl PartialEq for ApiFailure {
 impl Eq for ApiFailure {}
 
 impl fmt::Display for ApiFailure {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ApiFailure::Error(status, api_errors) => {
                 let mut output = format!("HTTP {status}");

--- a/cloudflare/src/framework/response/mod.rs
+++ b/cloudflare/src/framework/response/mod.rs
@@ -1,8 +1,7 @@
-extern crate reqwest;
-extern crate serde_json;
 mod apifail;
 
 pub use apifail::*;
+use serde::Deserialize;
 use serde_json::value::Value as JsonValue;
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]

--- a/cloudflare/src/lib.rs
+++ b/cloudflare/src/lib.rs
@@ -1,10 +1,2 @@
-///! An API client for the [Cloudflare API](https://api.cloudflare.com)
-extern crate chrono;
-extern crate reqwest;
-#[macro_use]
-extern crate serde;
-extern crate serde_json;
-extern crate url;
-
 pub mod endpoints;
 pub mod framework;


### PR DESCRIPTION
* Format/alphabetize `Cargo.toml`, ensure each has a license
* Fix edition 2018 idioms (`extern crate`, explicit elided lifetimes)
* Replace `maplit` with `HashMap::from` (`maplit` is no longer needed as of Rust 1.56.0)
* Fix rustdoc hyperlinks (`cargo doc` reminds us that links should have angle brackets)