### PR TITLE
Remove generic types for Endpoint::body and Endpoint::query

### DIFF
--- a/cloudflare-examples/src/main.rs
+++ b/cloudflare-examples/src/main.rs
@@ -215,12 +215,9 @@ fn delete_route(arg_matches: &ArgMatches, api_client: &HttpApiClient) {
 }
 
 /// Add and leak a mock (so it runs for 'static)
-fn add_static_mock<ResultType, QueryType, BodyType>(
-    endpoint: &dyn Endpoint<ResultType, QueryType, BodyType>,
-) where
+fn add_static_mock<ResultType>(endpoint: &dyn Endpoint<ResultType>)
+where
     ResultType: ApiResult,
-    QueryType: Serialize,
-    BodyType: Serialize,
 {
     let body = ApiErrors {
         errors: vec![ApiError {

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -13,6 +13,7 @@ default = ["default-tls"]
 blocking = ["reqwest/blocking"]
 default-tls = ["reqwest/default-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+spec = []
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = [
@@ -28,6 +29,7 @@ reqwest = { version = "0.11.4", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "2.0", features = ["base64"] }
+serde_urlencoded = "0.7.1"
 thiserror = "1"
 url = "2.2"
 uuid = { version = "1.0", features = ["serde"] }

--- a/cloudflare/src/endpoints/account/list_accounts.rs
+++ b/cloudflare/src/endpoints/account/list_accounts.rs
@@ -1,6 +1,6 @@
 use super::Account;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{serialize_query, EndpointSpec, Method};
 use crate::framework::OrderDirection;
 
 use serde::Serialize;
@@ -13,15 +13,16 @@ pub struct ListAccounts {
     pub params: Option<ListAccountsParams>,
 }
 
-impl Endpoint<Vec<Account>, ListAccountsParams> for ListAccounts {
+impl EndpointSpec<Vec<Account>> for ListAccounts {
     fn method(&self) -> Method {
         Method::GET
     }
     fn path(&self) -> String {
         "accounts".to_string()
     }
-    fn query(&self) -> Option<ListAccountsParams> {
-        self.params.clone()
+    #[inline]
+    fn query(&self) -> Option<String> {
+        serialize_query(&self.params)
     }
 }
 

--- a/cloudflare/src/endpoints/argo_tunnel/create_tunnel.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/create_tunnel.rs
@@ -5,7 +5,7 @@ use serde_with::{
     serde_as,
 };
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 use super::Tunnel;
 
@@ -19,15 +19,17 @@ pub struct CreateTunnel<'a> {
     pub params: Params<'a>,
 }
 
-impl<'a> Endpoint<Tunnel, (), Params<'a>> for CreateTunnel<'a> {
+impl<'a> EndpointSpec<Tunnel> for CreateTunnel<'a> {
     fn method(&self) -> Method {
         Method::POST
     }
     fn path(&self) -> String {
         format!("accounts/{}/tunnels", self.account_identifier)
     }
-    fn body(&self) -> Option<Params<'a>> {
-        Some(self.params.clone())
+    #[inline]
+    fn body(&self) -> Option<String> {
+        let body = serde_json::to_string(&self.params).unwrap();
+        Some(body)
     }
 }
 

--- a/cloudflare/src/endpoints/argo_tunnel/delete_tunnel.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/delete_tunnel.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 use super::Tunnel;
 
@@ -12,7 +12,7 @@ pub struct DeleteTunnel<'a> {
     pub cascade: bool,
 }
 
-impl<'a> Endpoint<Tunnel> for DeleteTunnel<'a> {
+impl<'a> EndpointSpec<Tunnel> for DeleteTunnel<'a> {
     fn method(&self) -> Method {
         Method::DELETE
     }

--- a/cloudflare/src/endpoints/argo_tunnel/list_tunnels.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/list_tunnels.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{serialize_query, EndpointSpec, Method};
 
 use super::Tunnel;
 
@@ -13,15 +13,16 @@ pub struct ListTunnels<'a> {
     pub params: Params,
 }
 
-impl<'a> Endpoint<Vec<Tunnel>, Params> for ListTunnels<'a> {
+impl<'a> EndpointSpec<Vec<Tunnel>> for ListTunnels<'a> {
     fn method(&self) -> Method {
         Method::GET
     }
     fn path(&self) -> String {
         format!("accounts/{}/tunnels", self.account_identifier)
     }
-    fn query(&self) -> Option<Params> {
-        Some(self.params.clone())
+    #[inline]
+    fn query(&self) -> Option<String> {
+        serialize_query(&self.params)
     }
 }
 

--- a/cloudflare/src/endpoints/argo_tunnel/route_dns.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/route_dns.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 use super::RouteResult;
 use serde::Serialize;
@@ -16,15 +16,17 @@ pub struct RouteTunnel<'a> {
     pub params: Params<'a>,
 }
 
-impl<'a> Endpoint<RouteResult, (), Params<'a>> for RouteTunnel<'a> {
+impl<'a> EndpointSpec<RouteResult> for RouteTunnel<'a> {
     fn method(&self) -> Method {
         Method::PUT
     }
     fn path(&self) -> String {
         format!("zones/{}/tunnels/{}/routes", self.zone_tag, self.tunnel_id)
     }
-    fn body(&self) -> Option<Params<'a>> {
-        Some(self.params.clone())
+    #[inline]
+    fn body(&self) -> Option<String> {
+        let body = serde_json::to_string(&self.params).unwrap();
+        Some(body)
     }
 }
 

--- a/cloudflare/src/endpoints/dns.rs
+++ b/cloudflare/src/endpoints/dns.rs
@@ -1,5 +1,5 @@
 use crate::framework::{
-    endpoint::{Endpoint, Method},
+    endpoint::{serialize_query, EndpointSpec, Method},
     response::ApiResult,
 };
 /// <https://api.cloudflare.com/#dns-records-for-a-zone-properties>
@@ -16,15 +16,16 @@ pub struct ListDnsRecords<'a> {
     pub zone_identifier: &'a str,
     pub params: ListDnsRecordsParams,
 }
-impl<'a> Endpoint<Vec<DnsRecord>, ListDnsRecordsParams> for ListDnsRecords<'a> {
+impl<'a> EndpointSpec<Vec<DnsRecord>> for ListDnsRecords<'a> {
     fn method(&self) -> Method {
         Method::GET
     }
     fn path(&self) -> String {
         format!("zones/{}/dns_records", self.zone_identifier)
     }
-    fn query(&self) -> Option<ListDnsRecordsParams> {
-        Some(self.params.clone())
+    #[inline]
+    fn query(&self) -> Option<String> {
+        serialize_query(&self.params)
     }
 }
 
@@ -36,15 +37,17 @@ pub struct CreateDnsRecord<'a> {
     pub params: CreateDnsRecordParams<'a>,
 }
 
-impl<'a> Endpoint<DnsRecord, (), CreateDnsRecordParams<'a>> for CreateDnsRecord<'a> {
+impl<'a> EndpointSpec<DnsRecord> for CreateDnsRecord<'a> {
     fn method(&self) -> Method {
         Method::POST
     }
     fn path(&self) -> String {
         format!("zones/{}/dns_records", self.zone_identifier)
     }
-    fn body(&self) -> Option<CreateDnsRecordParams<'a>> {
-        Some(self.params.clone())
+    #[inline]
+    fn body(&self) -> Option<String> {
+        let body = serde_json::to_string(&self.params).unwrap();
+        Some(body)
     }
 }
 
@@ -72,7 +75,7 @@ pub struct DeleteDnsRecord<'a> {
     pub zone_identifier: &'a str,
     pub identifier: &'a str,
 }
-impl<'a> Endpoint<DeleteDnsRecordResponse> for DeleteDnsRecord<'a> {
+impl<'a> EndpointSpec<DeleteDnsRecordResponse> for DeleteDnsRecord<'a> {
     fn method(&self) -> Method {
         Method::DELETE
     }
@@ -93,7 +96,7 @@ pub struct UpdateDnsRecord<'a> {
     pub params: UpdateDnsRecordParams<'a>,
 }
 
-impl<'a> Endpoint<DnsRecord, (), UpdateDnsRecordParams<'a>> for UpdateDnsRecord<'a> {
+impl<'a> EndpointSpec<DnsRecord> for UpdateDnsRecord<'a> {
     fn method(&self) -> Method {
         Method::PUT
     }
@@ -103,8 +106,10 @@ impl<'a> Endpoint<DnsRecord, (), UpdateDnsRecordParams<'a>> for UpdateDnsRecord<
             self.zone_identifier, self.identifier
         )
     }
-    fn body(&self) -> Option<UpdateDnsRecordParams<'a>> {
-        Some(self.params.clone())
+    #[inline]
+    fn body(&self) -> Option<String> {
+        let body = serde_json::to_string(&self.params).unwrap();
+        Some(body)
     }
 }
 

--- a/cloudflare/src/endpoints/load_balancing/create_lb.rs
+++ b/cloudflare/src/endpoints/load_balancing/create_lb.rs
@@ -2,7 +2,7 @@ use crate::endpoints::load_balancing::{
     LbPoolId, LbPoolMapping, LoadBalancer, SessionAffinity, SessionAffinityAttributes,
     SteeringPolicy,
 };
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 use serde::Serialize;
 
@@ -55,14 +55,16 @@ pub struct OptionalParams<'a> {
     pub session_affinity_ttl: Option<u32>,
 }
 
-impl<'a> Endpoint<LoadBalancer, (), Params<'a>> for CreateLoadBalancer<'a> {
+impl<'a> EndpointSpec<LoadBalancer> for CreateLoadBalancer<'a> {
     fn method(&self) -> Method {
         Method::POST
     }
     fn path(&self) -> String {
         format!("zones/{}/load_balancers", self.zone_identifier)
     }
-    fn body(&self) -> Option<Params<'a>> {
-        Some(self.params.clone())
+    #[inline]
+    fn body(&self) -> Option<String> {
+        let body = serde_json::to_string(&self.params).unwrap();
+        Some(body)
     }
 }

--- a/cloudflare/src/endpoints/load_balancing/create_pool.rs
+++ b/cloudflare/src/endpoints/load_balancing/create_pool.rs
@@ -1,5 +1,5 @@
 use crate::endpoints::load_balancing::{Origin, Pool};
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 use serde::Serialize;
 
@@ -51,14 +51,16 @@ pub struct OptionalParams<'a> {
     pub notification_email: Option<&'a str>,
 }
 
-impl<'a> Endpoint<Pool, (), Params<'a>> for CreatePool<'a> {
+impl<'a> EndpointSpec<Pool> for CreatePool<'a> {
     fn method(&self) -> Method {
         Method::POST
     }
     fn path(&self) -> String {
         format!("accounts/{}/load_balancers/pools", self.account_identifier)
     }
-    fn body(&self) -> Option<Params<'a>> {
-        Some(self.params.clone())
+    #[inline]
+    fn body(&self) -> Option<String> {
+        let body = serde_json::to_string(&self.params).unwrap();
+        Some(body)
     }
 }

--- a/cloudflare/src/endpoints/load_balancing/delete_lb.rs
+++ b/cloudflare/src/endpoints/load_balancing/delete_lb.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 use crate::framework::response::ApiResult;
 
 use serde::Deserialize;
@@ -13,7 +13,7 @@ pub struct DeleteLoadBalancer<'a> {
     pub identifier: &'a str,
 }
 
-impl<'a> Endpoint<Response, (), ()> for DeleteLoadBalancer<'a> {
+impl<'a> EndpointSpec<Response> for DeleteLoadBalancer<'a> {
     fn method(&self) -> Method {
         Method::DELETE
     }

--- a/cloudflare/src/endpoints/load_balancing/delete_pool.rs
+++ b/cloudflare/src/endpoints/load_balancing/delete_pool.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 use crate::framework::response::ApiResult;
 
 use serde::Deserialize;
@@ -13,7 +13,7 @@ pub struct DeletePool<'a> {
     pub identifier: &'a str,
 }
 
-impl<'a> Endpoint<Response, (), ()> for DeletePool<'a> {
+impl<'a> EndpointSpec<Response> for DeletePool<'a> {
     fn method(&self) -> Method {
         Method::DELETE
     }

--- a/cloudflare/src/endpoints/load_balancing/list_lb.rs
+++ b/cloudflare/src/endpoints/load_balancing/list_lb.rs
@@ -1,5 +1,5 @@
 use crate::endpoints::load_balancing::LoadBalancer;
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 use crate::framework::response::ApiResult;
 
 /// List Load Balancers
@@ -10,7 +10,7 @@ pub struct ListLoadBalancers<'a> {
     pub zone_identifier: &'a str,
 }
 
-impl<'a> Endpoint<Vec<LoadBalancer>, ()> for ListLoadBalancers<'a> {
+impl<'a> EndpointSpec<Vec<LoadBalancer>> for ListLoadBalancers<'a> {
     fn method(&self) -> Method {
         Method::GET
     }

--- a/cloudflare/src/endpoints/load_balancing/pool_details.rs
+++ b/cloudflare/src/endpoints/load_balancing/pool_details.rs
@@ -1,5 +1,5 @@
 use crate::endpoints::load_balancing::Pool;
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 /// Pool Details
 /// <https://api.cloudflare.com/#account-load-balancer-pools-pool-details>
@@ -11,7 +11,7 @@ pub struct PoolDetails<'a> {
     pub identifier: &'a str,
 }
 
-impl<'a> Endpoint<Pool, (), ()> for PoolDetails<'a> {
+impl<'a> EndpointSpec<Pool> for PoolDetails<'a> {
     fn method(&self) -> Method {
         Method::GET
     }

--- a/cloudflare/src/endpoints/r2.rs
+++ b/cloudflare/src/endpoints/r2.rs
@@ -3,7 +3,7 @@ use chrono::DateTime;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 use crate::framework::response::ApiResult;
 
 /// A Bucket is a collection of Objects stored in R2.
@@ -31,7 +31,7 @@ pub struct ListBuckets<'a> {
     pub account_identifier: &'a str,
 }
 
-impl<'a> Endpoint<ListBucketsResult> for ListBuckets<'a> {
+impl<'a> EndpointSpec<ListBucketsResult> for ListBuckets<'a> {
     fn method(&self) -> Method {
         Method::GET
     }
@@ -49,7 +49,7 @@ pub struct CreateBucket<'a> {
     pub bucket_name: &'a str,
 }
 
-impl<'a> Endpoint<EmptyMap> for CreateBucket<'a> {
+impl<'a> EndpointSpec<EmptyMap> for CreateBucket<'a> {
     fn method(&self) -> Method {
         Method::PUT
     }
@@ -68,7 +68,7 @@ pub struct DeleteBucket<'a> {
     pub bucket_name: &'a str,
 }
 
-impl<'a> Endpoint<EmptyMap> for DeleteBucket<'a> {
+impl<'a> EndpointSpec<EmptyMap> for DeleteBucket<'a> {
     fn method(&self) -> Method {
         Method::DELETE
     }

--- a/cloudflare/src/endpoints/user.rs
+++ b/cloudflare/src/endpoints/user.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 use crate::framework::response::ApiResult;
 
 use chrono::{DateTime, Utc};
@@ -68,7 +68,7 @@ fn handles_empty_betas_field() {
 #[derive(Debug)]
 pub struct GetUserDetails {}
 
-impl Endpoint<UserDetails, (), ()> for GetUserDetails {
+impl EndpointSpec<UserDetails> for GetUserDetails {
     fn method(&self) -> Method {
         Method::GET
     }
@@ -91,7 +91,7 @@ impl ApiResult for UserTokenStatus {}
 #[derive(Debug)]
 pub struct GetUserTokenStatus {}
 
-impl Endpoint<UserTokenStatus, (), ()> for GetUserTokenStatus {
+impl EndpointSpec<UserTokenStatus> for GetUserTokenStatus {
     fn method(&self) -> Method {
         Method::GET
     }

--- a/cloudflare/src/endpoints/workers/create_route.rs
+++ b/cloudflare/src/endpoints/workers/create_route.rs
@@ -1,6 +1,6 @@
 use super::WorkersRouteIdOnly;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 use serde::Serialize;
 
@@ -13,15 +13,17 @@ pub struct CreateRoute<'a> {
     pub params: CreateRouteParams,
 }
 
-impl<'a> Endpoint<WorkersRouteIdOnly, (), CreateRouteParams> for CreateRoute<'a> {
+impl<'a> EndpointSpec<WorkersRouteIdOnly> for CreateRoute<'a> {
     fn method(&self) -> Method {
         Method::POST
     }
     fn path(&self) -> String {
         format!("zones/{}/workers/routes", self.zone_identifier)
     }
-    fn body(&self) -> Option<CreateRouteParams> {
-        Some(self.params.clone())
+    #[inline]
+    fn body(&self) -> Option<String> {
+        let body = serde_json::to_string(&self.params).unwrap();
+        Some(body)
     }
 }
 

--- a/cloudflare/src/endpoints/workers/create_secret.rs
+++ b/cloudflare/src/endpoints/workers/create_secret.rs
@@ -1,6 +1,6 @@
 use super::WorkersSecret;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 use serde::Serialize;
 
@@ -16,7 +16,7 @@ pub struct CreateSecret<'a> {
     pub params: CreateSecretParams,
 }
 
-impl<'a> Endpoint<WorkersSecret, (), CreateSecretParams> for CreateSecret<'a> {
+impl<'a> EndpointSpec<WorkersSecret> for CreateSecret<'a> {
     fn method(&self) -> Method {
         Method::PUT
     }
@@ -26,8 +26,10 @@ impl<'a> Endpoint<WorkersSecret, (), CreateSecretParams> for CreateSecret<'a> {
             self.account_identifier, self.script_name
         )
     }
-    fn body(&self) -> Option<CreateSecretParams> {
-        Some(self.params.clone())
+    #[inline]
+    fn body(&self) -> Option<String> {
+        let body = serde_json::to_string(&self.params).unwrap();
+        Some(body)
     }
 }
 

--- a/cloudflare/src/endpoints/workers/create_tail.rs
+++ b/cloudflare/src/endpoints/workers/create_tail.rs
@@ -1,6 +1,6 @@
 use super::WorkersTail;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 use serde::Serialize;
 
@@ -20,7 +20,7 @@ pub struct CreateTail<'a> {
     pub params: CreateTailParams,
 }
 
-impl<'a> Endpoint<WorkersTail, (), CreateTailParams> for CreateTail<'a> {
+impl<'a> EndpointSpec<WorkersTail> for CreateTail<'a> {
     fn method(&self) -> Method {
         Method::POST
     }
@@ -30,9 +30,11 @@ impl<'a> Endpoint<WorkersTail, (), CreateTailParams> for CreateTail<'a> {
             self.account_identifier, self.script_name
         )
     }
-    fn body(&self) -> Option<CreateTailParams> {
+    #[inline]
+    fn body(&self) -> Option<String> {
         if self.params.url.is_some() {
-            Some(self.params.clone())
+            let body = serde_json::to_string(&self.params).unwrap();
+            Some(body)
         } else {
             None
         }

--- a/cloudflare/src/endpoints/workers/delete_do.rs
+++ b/cloudflare/src/endpoints/workers/delete_do.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 /// Delete a Durable Object namespace
 #[derive(Debug)]
@@ -9,7 +9,7 @@ pub struct DeleteDurableObject<'a> {
     pub namespace_id: &'a str,
 }
 
-impl<'a> Endpoint<(), (), ()> for DeleteDurableObject<'a> {
+impl<'a> EndpointSpec<()> for DeleteDurableObject<'a> {
     fn method(&self) -> Method {
         Method::DELETE
     }

--- a/cloudflare/src/endpoints/workers/delete_route.rs
+++ b/cloudflare/src/endpoints/workers/delete_route.rs
@@ -1,6 +1,6 @@
 use super::WorkersRouteIdOnly;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 /// Delete a Route
 /// Deletes a route by route id
@@ -11,7 +11,7 @@ pub struct DeleteRoute<'a> {
     pub identifier: &'a str,
 }
 
-impl<'a> Endpoint<WorkersRouteIdOnly> for DeleteRoute<'a> {
+impl<'a> EndpointSpec<WorkersRouteIdOnly> for DeleteRoute<'a> {
     fn method(&self) -> Method {
         Method::DELETE
     }

--- a/cloudflare/src/endpoints/workers/delete_script.rs
+++ b/cloudflare/src/endpoints/workers/delete_script.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 use crate::framework::response::ApiResult;
 
 use serde::{Deserialize, Serialize};
@@ -13,7 +13,7 @@ pub struct DeleteScript<'a> {
     pub script_name: &'a str,
 }
 
-impl<'a> Endpoint<ScriptDeleteID, (), ()> for DeleteScript<'a> {
+impl<'a> EndpointSpec<ScriptDeleteID> for DeleteScript<'a> {
     fn method(&self) -> Method {
         Method::DELETE
     }

--- a/cloudflare/src/endpoints/workers/delete_secret.rs
+++ b/cloudflare/src/endpoints/workers/delete_secret.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 /// Delete Secret
 /// <https://api.cloudflare.com/#worker-delete-secret>
@@ -12,7 +12,7 @@ pub struct DeleteSecret<'a> {
     pub secret_name: &'a str,
 }
 
-impl<'a> Endpoint<(), (), ()> for DeleteSecret<'a> {
+impl<'a> EndpointSpec<()> for DeleteSecret<'a> {
     fn method(&self) -> Method {
         Method::DELETE
     }

--- a/cloudflare/src/endpoints/workers/delete_tail.rs
+++ b/cloudflare/src/endpoints/workers/delete_tail.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 /// Delete Tail
 /// <https://api.cloudflare.com/#worker-delete-tail>
@@ -12,7 +12,7 @@ pub struct DeleteTail<'a> {
     pub tail_id: &'a str,
 }
 
-impl<'a> Endpoint<()> for DeleteTail<'a> {
+impl<'a> EndpointSpec<()> for DeleteTail<'a> {
     fn method(&self) -> Method {
         Method::DELETE
     }

--- a/cloudflare/src/endpoints/workers/list_bindings.rs
+++ b/cloudflare/src/endpoints/workers/list_bindings.rs
@@ -1,5 +1,5 @@
 use super::WorkersBinding;
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 /// List Bindings
 /// Lists all bindings for a given script
@@ -11,7 +11,7 @@ pub struct ListBindings<'a> {
     pub script_name: &'a str,
 }
 
-impl<'a> Endpoint<Vec<WorkersBinding>> for ListBindings<'a> {
+impl<'a> EndpointSpec<Vec<WorkersBinding>> for ListBindings<'a> {
     fn method(&self) -> Method {
         Method::GET
     }

--- a/cloudflare/src/endpoints/workers/list_routes.rs
+++ b/cloudflare/src/endpoints/workers/list_routes.rs
@@ -1,6 +1,6 @@
 use super::WorkersRoute;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 /// List Routes
 /// Lists all route mappings for a given zone
@@ -10,7 +10,7 @@ pub struct ListRoutes<'a> {
     pub zone_identifier: &'a str,
 }
 
-impl<'a> Endpoint<Vec<WorkersRoute>> for ListRoutes<'a> {
+impl<'a> EndpointSpec<Vec<WorkersRoute>> for ListRoutes<'a> {
     fn method(&self) -> Method {
         Method::GET
     }

--- a/cloudflare/src/endpoints/workers/list_secrets.rs
+++ b/cloudflare/src/endpoints/workers/list_secrets.rs
@@ -1,6 +1,6 @@
 use super::WorkersSecret;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 /// List Secrets
 /// Lists all secrets mappings for a given script
@@ -11,7 +11,7 @@ pub struct ListSecrets<'a> {
     pub script_name: &'a str,
 }
 
-impl<'a> Endpoint<Vec<WorkersSecret>> for ListSecrets<'a> {
+impl<'a> EndpointSpec<Vec<WorkersSecret>> for ListSecrets<'a> {
     fn method(&self) -> Method {
         Method::GET
     }

--- a/cloudflare/src/endpoints/workers/list_tails.rs
+++ b/cloudflare/src/endpoints/workers/list_tails.rs
@@ -1,6 +1,6 @@
 use super::WorkersTail;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 /// List Tails
 /// Lists all active Tail sessions for a given Worker
@@ -11,7 +11,7 @@ pub struct ListTails<'a> {
     pub script_name: &'a str,
 }
 
-impl<'a> Endpoint<Vec<WorkersTail>> for ListTails<'a> {
+impl<'a> EndpointSpec<Vec<WorkersTail>> for ListTails<'a> {
     fn method(&self) -> Method {
         Method::GET
     }

--- a/cloudflare/src/endpoints/workers/send_tail_heartbeat.rs
+++ b/cloudflare/src/endpoints/workers/send_tail_heartbeat.rs
@@ -1,6 +1,6 @@
 use super::WorkersTail;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 /// Send Tail Heartbeat
 /// <https://api.cloudflare.com/#worker-tail-heartbeat>
@@ -14,7 +14,7 @@ pub struct SendTailHeartbeat<'a> {
     pub tail_id: &'a str,
 }
 
-impl<'a> Endpoint<WorkersTail> for SendTailHeartbeat<'a> {
+impl<'a> EndpointSpec<WorkersTail> for SendTailHeartbeat<'a> {
     fn method(&self) -> Method {
         Method::POST
     }

--- a/cloudflare/src/endpoints/workerskv/create_namespace.rs
+++ b/cloudflare/src/endpoints/workerskv/create_namespace.rs
@@ -1,6 +1,6 @@
 use super::WorkersKvNamespace;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 use serde::Serialize;
 
@@ -15,15 +15,17 @@ pub struct CreateNamespace<'a> {
     pub params: CreateNamespaceParams,
 }
 
-impl<'a> Endpoint<WorkersKvNamespace, (), CreateNamespaceParams> for CreateNamespace<'a> {
+impl<'a> EndpointSpec<WorkersKvNamespace> for CreateNamespace<'a> {
     fn method(&self) -> Method {
         Method::POST
     }
     fn path(&self) -> String {
         format!("accounts/{}/storage/kv/namespaces", self.account_identifier)
     }
-    fn body(&self) -> Option<CreateNamespaceParams> {
-        Some(self.params.clone())
+    #[inline]
+    fn body(&self) -> Option<String> {
+        let body = serde_json::to_string(&self.params).unwrap();
+        Some(body)
     }
 }
 

--- a/cloudflare/src/endpoints/workerskv/delete_bulk.rs
+++ b/cloudflare/src/endpoints/workerskv/delete_bulk.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 /// Delete Key-Value Pairs in Bulk
 /// Deletes multiple key-value pairs from Workers KV at once.
@@ -11,7 +11,7 @@ pub struct DeleteBulk<'a> {
     pub bulk_keys: Vec<String>,
 }
 
-impl<'a> Endpoint<(), (), Vec<String>> for DeleteBulk<'a> {
+impl<'a> EndpointSpec<()> for DeleteBulk<'a> {
     fn method(&self) -> Method {
         Method::DELETE
     }
@@ -21,8 +21,10 @@ impl<'a> Endpoint<(), (), Vec<String>> for DeleteBulk<'a> {
             self.account_identifier, self.namespace_identifier
         )
     }
-    fn body(&self) -> Option<Vec<String>> {
-        Some(self.bulk_keys.clone())
+    #[inline]
+    fn body(&self) -> Option<String> {
+        let body = serde_json::to_string(&self.bulk_keys).unwrap();
+        Some(body)
     }
     // default content-type is already application/json
 }

--- a/cloudflare/src/endpoints/workerskv/delete_key.rs
+++ b/cloudflare/src/endpoints/workerskv/delete_key.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 /// Delete a key-value pair from Workers KV
 /// Deletes a given key from the given namespace in Workers KV.
@@ -11,7 +11,7 @@ pub struct DeleteKey<'a> {
     pub key: &'a str,
 }
 
-impl<'a> Endpoint<(), (), ()> for DeleteKey<'a> {
+impl<'a> EndpointSpec<()> for DeleteKey<'a> {
     fn method(&self) -> Method {
         Method::DELETE
     }

--- a/cloudflare/src/endpoints/workerskv/list_namespace_keys.rs
+++ b/cloudflare/src/endpoints/workerskv/list_namespace_keys.rs
@@ -1,6 +1,6 @@
 use super::Key;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{serialize_query, EndpointSpec, Method};
 
 use serde::Serialize;
 
@@ -13,7 +13,7 @@ pub struct ListNamespaceKeys<'a> {
     pub params: ListNamespaceKeysParams,
 }
 
-impl<'a> Endpoint<Vec<Key>, ListNamespaceKeysParams> for ListNamespaceKeys<'a> {
+impl<'a> EndpointSpec<Vec<Key>> for ListNamespaceKeys<'a> {
     fn method(&self) -> Method {
         Method::GET
     }
@@ -23,8 +23,9 @@ impl<'a> Endpoint<Vec<Key>, ListNamespaceKeysParams> for ListNamespaceKeys<'a> {
             self.account_identifier, self.namespace_identifier
         )
     }
-    fn query(&self) -> Option<ListNamespaceKeysParams> {
-        Some(self.params.clone())
+    #[inline]
+    fn query(&self) -> Option<String> {
+        serialize_query(&self.params)
     }
 }
 

--- a/cloudflare/src/endpoints/workerskv/list_namespaces.rs
+++ b/cloudflare/src/endpoints/workerskv/list_namespaces.rs
@@ -1,6 +1,6 @@
 use super::WorkersKvNamespace;
 
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{serialize_query, EndpointSpec, Method};
 
 use serde::Serialize;
 
@@ -13,15 +13,16 @@ pub struct ListNamespaces<'a> {
     pub params: ListNamespacesParams,
 }
 
-impl<'a> Endpoint<Vec<WorkersKvNamespace>, ListNamespacesParams> for ListNamespaces<'a> {
+impl<'a> EndpointSpec<Vec<WorkersKvNamespace>> for ListNamespaces<'a> {
     fn method(&self) -> Method {
         Method::GET
     }
     fn path(&self) -> String {
         format!("accounts/{}/storage/kv/namespaces", self.account_identifier)
     }
-    fn query(&self) -> Option<ListNamespacesParams> {
-        Some(self.params.clone())
+    #[inline]
+    fn query(&self) -> Option<String> {
+        serialize_query(&self.params)
     }
 }
 

--- a/cloudflare/src/endpoints/workerskv/remove_namespace.rs
+++ b/cloudflare/src/endpoints/workerskv/remove_namespace.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 /// Remove a Namespace
 /// Deletes the namespace corresponding to the given ID.
@@ -9,7 +9,7 @@ pub struct RemoveNamespace<'a> {
     pub namespace_identifier: &'a str,
 }
 
-impl<'a> Endpoint for RemoveNamespace<'a> {
+impl<'a> EndpointSpec<()> for RemoveNamespace<'a> {
     fn method(&self) -> Method {
         Method::DELETE
     }

--- a/cloudflare/src/endpoints/workerskv/rename_namespace.rs
+++ b/cloudflare/src/endpoints/workerskv/rename_namespace.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 use serde::Serialize;
 
@@ -12,7 +12,7 @@ pub struct RenameNamespace<'a> {
     pub params: RenameNamespaceParams,
 }
 
-impl<'a> Endpoint<(), (), RenameNamespaceParams> for RenameNamespace<'a> {
+impl<'a> EndpointSpec<()> for RenameNamespace<'a> {
     fn method(&self) -> Method {
         Method::PUT
     }
@@ -22,8 +22,10 @@ impl<'a> Endpoint<(), (), RenameNamespaceParams> for RenameNamespace<'a> {
             self.account_identifier, self.namespace_identifier
         )
     }
-    fn body(&self) -> Option<RenameNamespaceParams> {
-        Some(self.params.clone())
+    #[inline]
+    fn body(&self) -> Option<String> {
+        let body = serde_json::to_string(&self.params).unwrap();
+        Some(body)
     }
 }
 

--- a/cloudflare/src/endpoints/workerskv/write_bulk.rs
+++ b/cloudflare/src/endpoints/workerskv/write_bulk.rs
@@ -1,4 +1,4 @@
-use crate::framework::endpoint::{Endpoint, Method};
+use crate::framework::endpoint::{EndpointSpec, Method};
 
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +13,7 @@ pub struct WriteBulk<'a> {
     pub bulk_key_value_pairs: Vec<KeyValuePair>,
 }
 
-impl<'a> Endpoint<(), (), Vec<KeyValuePair>> for WriteBulk<'a> {
+impl<'a> EndpointSpec<()> for WriteBulk<'a> {
     fn method(&self) -> Method {
         Method::PUT
     }
@@ -23,8 +23,11 @@ impl<'a> Endpoint<(), (), Vec<KeyValuePair>> for WriteBulk<'a> {
             self.account_identifier, self.namespace_identifier
         )
     }
-    fn body(&self) -> Option<Vec<KeyValuePair>> {
-        Some(self.bulk_key_value_pairs.clone())
+
+    #[inline]
+    fn body(&self) -> Option<String> {
+        let body = serde_json::to_string(&self.bulk_key_value_pairs).unwrap();
+        Some(body)
     }
     // default content-type is already application/json
 }

--- a/cloudflare/src/endpoints/zone.rs
+++ b/cloudflare/src/endpoints/zone.rs
@@ -1,6 +1,7 @@
 use crate::endpoints::{account::AccountDetails, plan::Plan};
+use crate::framework::endpoint::serialize_query;
 use crate::framework::{
-    endpoint::{Endpoint, Method},
+    endpoint::{EndpointSpec, Method},
     response::ApiResult,
 };
 use crate::framework::{OrderDirection, SearchMatch};
@@ -16,15 +17,16 @@ pub struct ListZones {
     pub params: ListZonesParams,
 }
 
-impl Endpoint<Vec<Zone>, ListZonesParams> for ListZones {
+impl EndpointSpec<Vec<Zone>> for ListZones {
     fn method(&self) -> Method {
         Method::GET
     }
     fn path(&self) -> String {
         "zones".to_string()
     }
-    fn query(&self) -> Option<ListZonesParams> {
-        Some(self.params.clone())
+    #[inline]
+    fn query(&self) -> Option<String> {
+        serialize_query(&self.params)
     }
 }
 
@@ -34,7 +36,7 @@ impl Endpoint<Vec<Zone>, ListZonesParams> for ListZones {
 pub struct ZoneDetails<'a> {
     pub identifier: &'a str,
 }
-impl<'a> Endpoint<Zone> for ZoneDetails<'a> {
+impl<'a> EndpointSpec<Zone> for ZoneDetails<'a> {
     fn method(&self) -> Method {
         Method::GET
     }
@@ -48,7 +50,7 @@ impl<'a> Endpoint<Zone> for ZoneDetails<'a> {
 pub struct CreateZone<'a> {
     pub params: CreateZoneParams<'a>,
 }
-impl<'a> Endpoint<(), (), CreateZoneParams<'a>> for CreateZone<'a> {
+impl<'a> EndpointSpec<()> for CreateZone<'a> {
     fn method(&self) -> Method {
         Method::POST
     }
@@ -57,8 +59,10 @@ impl<'a> Endpoint<(), (), CreateZoneParams<'a>> for CreateZone<'a> {
         "zones".to_string()
     }
 
-    fn body(&self) -> Option<CreateZoneParams<'a>> {
-        Some(self.params.clone())
+    #[inline]
+    fn body(&self) -> Option<String> {
+        let body = serde_json::to_string(&self.params).unwrap();
+        Some(body)
     }
 }
 

--- a/cloudflare/src/framework/endpoint.rs
+++ b/cloudflare/src/framework/endpoint.rs
@@ -1,28 +1,79 @@
 use crate::framework::response::ApiResult;
 use crate::framework::Environment;
 use serde::Serialize;
+use std::borrow::Cow;
 use url::Url;
 
 pub use http::Method;
 
-pub trait Endpoint<ResultType = (), QueryType = (), BodyType = ()>
-where
-    ResultType: ApiResult,
-    QueryType: Serialize,
-    BodyType: Serialize,
-{
-    fn method(&self) -> Method;
-    fn path(&self) -> String;
-    fn query(&self) -> Option<QueryType> {
-        None
+#[cfg(feature = "endpoint-spec")]
+pub use spec::EndpointSpec;
+#[cfg(not(feature = "endpoint-spec"))]
+pub(crate) use spec::EndpointSpec;
+
+// This is the internal-only representation. To avoid bloat from monomorphization, the query
+// string, body, etc are generally not exposed publicly, though it can be exposed via the
+// "endpoint-spec" feature.
+mod spec {
+    use super::*;
+
+    /// Represents a specification for an API call that can be built into an HTTP request and sent.
+    /// New endpoints should implement this trait.
+    ///
+    /// If the request succeeds, the call will resolve to a `ResultType`.
+    pub trait EndpointSpec<ResultType>
+    where
+        ResultType: ApiResult,
+    {
+        /// The HTTP Method used for this endpoint (e.g. GET, PATCH, DELETE)
+        fn method(&self) -> http::Method;
+
+        /// The relative URL path for this endpoint
+        fn path(&self) -> String;
+
+        /// The url-encoded query string associated with this endpoint. Defaults to `None`.
+        ///
+        /// Implementors should inline this.
+        #[inline]
+        fn query(&self) -> Option<String> {
+            None
+        }
+
+        /// The HTTP body associated with this endpoint. If not implemented, defaults to `None`.
+        ///
+        /// Implementors should inline this.
+        #[inline]
+        fn body(&self) -> Option<String> {
+            None
+        }
+
+        /// Builds and returns a formatted full URL, including query, for the endpoint.
+        ///
+        /// Implementors should generally not override this.
+        fn url(&self, environment: &Environment) -> Url {
+            let mut url = Url::from(environment).join(&self.path()).unwrap();
+            url.set_query(self.query().as_deref());
+            url
+        }
+
+        /// If `body` is populated, indicates the body MIME type (defaults to JSON).
+        ///
+        /// Implementors generally do not need to override this.
+        fn content_type(&self) -> Cow<'static, str> {
+            Cow::Borrowed("application/json")
+        }
     }
-    fn body(&self) -> Option<BodyType> {
-        None
-    }
-    fn url(&self, environment: &Environment) -> Url {
-        Url::from(environment).join(&self.path()).unwrap()
-    }
-    fn content_type(&self) -> String {
-        "application/json".to_owned()
-    }
+}
+// Auto-implement the public Endpoint trait for EndpointInternal implementors.
+impl<T: ApiResult, U: EndpointSpec<T>> Endpoint<T> for U {}
+
+/// An API call that can be built into an HTTP request and sent.
+///
+/// If the request succeeds, the call will resolve to a `ResultType`.
+pub trait Endpoint<ResultType: ApiResult>: spec::EndpointSpec<ResultType> {}
+
+/// A utility function for serializing parameters into a URL query string.
+#[inline]
+pub(crate) fn serialize_query<Q: Serialize>(q: &Q) -> Option<String> {
+    serde_urlencoded::to_string(q).ok()
 }


### PR DESCRIPTION
Simplifies the ergonomics for Endpoint users by removing some irrelevant generic parameters and hiding implementation details. Slightly improves codegen (~15% smaller) and build times.