### PR TITLE
Derive debug for async client

### DIFF
--- a/cloudflare/src/framework/async_api.rs
+++ b/cloudflare/src/framework/async_api.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 use std::net::SocketAddr;
 
 /// A Cloudflare API client that makes requests asynchronously.
+#[derive(Debug)]
 pub struct Client {
     environment: Environment,
     credentials: auth::Credentials,


### PR DESCRIPTION
This change annotates `cloudflare::framework::async_api::Client` with `#[derive(Debug)]` as per #214.