### PR TITLE
Derive PartialEq for DnsContent

### DIFF
--- a/cloudflare/src/endpoints/dns.rs
+++ b/cloudflare/src/endpoints/dns.rs
@@ -161,7 +161,7 @@ pub struct Meta {
 /// Type of the DNS record, along with the associated value.
 /// When we add support for other types (LOC/SRV/...), the `meta` field should also probably be encoded
 /// here as an associated, strongly typed value.
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, PartialEq, Debug)]
 #[serde(tag = "type")]
 #[allow(clippy::upper_case_acronyms)]
 pub enum DnsContent {


### PR DESCRIPTION
Currently, comparisons between `DnsContent` instances require explicit matching of the enum variants, which can be cumbersome.

```rust
let dns1: DnsContent = ...;
let dns2: DnsContent = ...;

let same_record: bool = match (dns1, dns2) {
    (DnsContent::A { content: ip1 }, DnsContent::A { content: ip2 }) => ip1 == ip2,
    // ...
    _ => false
};
```

 By deriving `PartialEq`, `DnsContent` instances can be compared using the `==` operator, providing a more natural and ergonomic API for working with DNS records.

```rust
let dns1: DnsContent = ...;
let dns2: DnsContent = ...;

let same_record: bool = dns1 == dns2;
```