### PR TITLE
Add support for reqwest's rustls roots features

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -13,6 +13,8 @@ default = ["default-tls"]
 blocking = ["reqwest/blocking"]
 default-tls = ["reqwest/default-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
 spec = []
 
 [dependencies]


### PR DESCRIPTION
Adds support for reqwest's rustls roots features `rustls-tls-native-roots` and `rustls-tls-webpki-roots`.

This addresses https://github.com/cloudflare/cloudflare-rs/issues/228.