### PR TITLE
Add proc macro to derive ApiResult

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "cloudflare",
+    "cloudflare-derive-macros",
     "cloudflare-examples",
     "cloudflare-e2e-test",
 ]

--- a/cloudflare-derive-macros/Cargo.toml
+++ b/cloudflare-derive-macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cloudflare-derive-macros"
+version = "0.1.0"
+edition = "2018"
+description = "Internal macros for the Cloudflare crate"
+license = "BSD-3-Clause"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"

--- a/cloudflare-derive-macros/src/lib.rs
+++ b/cloudflare-derive-macros/src/lib.rs
@@ -1,0 +1,29 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(ApiResult)]
+pub fn api_result_derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let name = &ast.ident;
+
+    let gen = quote! {
+        impl crate::framework::response::ApiResult for #name {}
+    };
+
+    gen.into()
+}
+
+#[proc_macro_derive(VecApiResult)]
+pub fn vec_api_result_derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let name = &ast.ident;
+
+    let gen = quote! {
+        impl crate::framework::response::ApiResult for Vec<#name> {}
+    };
+
+    gen.into()
+}

--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -33,3 +33,4 @@ serde_urlencoded = "0.7.1"
 thiserror = "1"
 url = "2.2"
 uuid = { version = "1.0", features = ["serde"] }
+cloudflare-derive-macros = { path = "../cloudflare-derive-macros" }

--- a/cloudflare/src/endpoints/account/mod.rs
+++ b/cloudflare/src/endpoints/account/mod.rs
@@ -1,5 +1,5 @@
-use crate::framework::response::ApiResult;
 use chrono::{DateTime, Utc};
+use cloudflare_derive_macros::{ApiResult, VecApiResult};
 use serde::{Deserialize, Serialize};
 
 pub mod list_accounts;
@@ -8,7 +8,7 @@ pub use list_accounts::ListAccounts;
 /// Cloudflare Accounts
 /// An Account is the root object which owns other resources such as zones, load balancers and billing details.
 /// <https://api.cloudflare.com/#accounts-properties>
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ApiResult, VecApiResult)]
 pub struct Account {
     /// Account identifier tag.
     pub id: String,
@@ -38,6 +38,3 @@ pub struct AccountDetails {
     /// Account name
     pub name: String,
 }
-
-impl ApiResult for Account {}
-impl ApiResult for Vec<Account> {}

--- a/cloudflare/src/endpoints/argo_tunnel/data_structures.rs
+++ b/cloudflare/src/endpoints/argo_tunnel/data_structures.rs
@@ -1,13 +1,12 @@
 use chrono::{offset::Utc, DateTime};
+use cloudflare_derive_macros::{ApiResult, VecApiResult};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-
-use crate::framework::response::ApiResult;
 
 /// A Named Argo Tunnel
 /// This is an Argo Tunnel that has been created. It can be used for routing and subsequent running.
 /// <https://api.cloudflare.com/#argo-tunnel-properties>
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ApiResult, VecApiResult)]
 pub struct Tunnel {
     pub id: Uuid,
     pub created_at: DateTime<Utc>,
@@ -26,11 +25,8 @@ pub struct ActiveConnection {
     pub is_pending_reconnect: bool,
 }
 
-impl ApiResult for Tunnel {}
-impl ApiResult for Vec<Tunnel> {}
-
 /// The result of a route request for a Named Argo Tunnel
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ApiResult)]
 #[serde(untagged)]
 pub enum RouteResult {
     Dns(DnsRouteResult),
@@ -55,5 +51,3 @@ pub enum Change {
     New,
     Updated,
 }
-
-impl ApiResult for RouteResult {}

--- a/cloudflare/src/endpoints/dns.rs
+++ b/cloudflare/src/endpoints/dns.rs
@@ -1,11 +1,9 @@
-use crate::framework::{
-    endpoint::{serialize_query, EndpointSpec, Method},
-    response::ApiResult,
-};
+use crate::framework::endpoint::{serialize_query, EndpointSpec, Method};
 /// <https://api.cloudflare.com/#dns-records-for-a-zone-properties>
 use crate::framework::{OrderDirection, SearchMatch};
 use chrono::offset::Utc;
 use chrono::DateTime;
+use cloudflare_derive_macros::{ApiResult, VecApiResult};
 use serde::{Deserialize, Serialize};
 use std::net::{Ipv4Addr, Ipv6Addr};
 
@@ -174,13 +172,13 @@ pub enum DnsContent {
     SRV { content: String },
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ApiResult)]
 pub struct DeleteDnsRecordResponse {
     /// DNS record identifier tag
     pub id: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ApiResult, VecApiResult)]
 pub struct DnsRecord {
     /// Extra Cloudflare-specific information about the record
     pub meta: Meta,
@@ -208,7 +206,3 @@ pub struct DnsRecord {
     /// The domain of the record
     pub zone_name: String,
 }
-
-impl ApiResult for DnsRecord {}
-impl ApiResult for Vec<DnsRecord> {}
-impl ApiResult for DeleteDnsRecordResponse {}

--- a/cloudflare/src/endpoints/load_balancing/delete_lb.rs
+++ b/cloudflare/src/endpoints/load_balancing/delete_lb.rs
@@ -1,6 +1,6 @@
 use crate::framework::endpoint::{EndpointSpec, Method};
-use crate::framework::response::ApiResult;
 
+use cloudflare_derive_macros::ApiResult;
 use serde::Deserialize;
 
 /// Delete Load Balancer
@@ -25,8 +25,7 @@ impl<'a> EndpointSpec<Response> for DeleteLoadBalancer<'a> {
     }
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug, ApiResult)]
 pub struct Response {
     pub id: String,
 }
-impl ApiResult for Response {}

--- a/cloudflare/src/endpoints/load_balancing/delete_pool.rs
+++ b/cloudflare/src/endpoints/load_balancing/delete_pool.rs
@@ -1,6 +1,6 @@
 use crate::framework::endpoint::{EndpointSpec, Method};
-use crate::framework::response::ApiResult;
 
+use cloudflare_derive_macros::ApiResult;
 use serde::Deserialize;
 
 /// Delete Pool
@@ -25,8 +25,7 @@ impl<'a> EndpointSpec<Response> for DeletePool<'a> {
     }
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug, ApiResult)]
 pub struct Response {
     pub id: String,
 }
-impl ApiResult for Response {}

--- a/cloudflare/src/endpoints/load_balancing/list_lb.rs
+++ b/cloudflare/src/endpoints/load_balancing/list_lb.rs
@@ -1,6 +1,5 @@
 use crate::endpoints::load_balancing::LoadBalancer;
 use crate::framework::endpoint::{EndpointSpec, Method};
-use crate::framework::response::ApiResult;
 
 /// List Load Balancers
 /// <https://api.cloudflare.com/#load-balancers-list-load-balancers>
@@ -18,5 +17,3 @@ impl<'a> EndpointSpec<Vec<LoadBalancer>> for ListLoadBalancers<'a> {
         format!("zones/{}/load_balancers", self.zone_identifier)
     }
 }
-
-impl ApiResult for Vec<LoadBalancer> {}

--- a/cloudflare/src/endpoints/load_balancing/mod.rs
+++ b/cloudflare/src/endpoints/load_balancing/mod.rs
@@ -5,15 +5,15 @@ pub mod delete_pool;
 pub mod list_lb;
 pub mod pool_details;
 
-use crate::framework::response::ApiResult;
 use chrono::offset::Utc;
 use chrono::DateTime;
+use cloudflare_derive_macros::{ApiResult, VecApiResult};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 
-#[derive(Eq, PartialEq, Deserialize, Serialize, Clone, Debug)]
+#[derive(Eq, PartialEq, Deserialize, Serialize, Clone, Debug, ApiResult, VecApiResult)]
 pub struct LoadBalancer {
     pub id: String,
     pub created_on: DateTime<Utc>,
@@ -108,8 +108,6 @@ pub enum Secure {
     Never,
 }
 
-impl ApiResult for LoadBalancer {}
-
 /// A pool is a set of origins that requests could be routed to (e.g. each of your data centers or
 /// regions have its own pool).
 /// Requests will be routed to particular pools according to your steering policy, and then balanced
@@ -120,7 +118,7 @@ impl ApiResult for LoadBalancer {}
 /// handle. Then you might use a "dynamic latency" steering policy to ensure requests get routed
 /// to whatever pool can serve them fastest. So US users will probably get routed to the US pool. If
 /// the US pool becomes unavailable, they'll fail over to the Oceania pool.
-#[derive(Eq, PartialEq, Deserialize, Serialize, Clone, Debug)]
+#[derive(Eq, PartialEq, Deserialize, Serialize, Clone, Debug, ApiResult)]
 pub struct Pool {
     pub id: String,
     pub created_on: DateTime<Utc>,
@@ -151,7 +149,7 @@ pub struct Pool {
 /// An origin represents something that can serve user requests. Usually a machine, maybe an ELB.
 /// Origins with similar latency functions (e.g. origins in the same data center or region) might be
 /// in the same pool.
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, ApiResult)]
 pub struct Origin {
     /// A human-identifiable name for the origin.
     /// e.g. app-server-1
@@ -190,6 +188,3 @@ impl Hash for Origin {
         self.weight.to_bits().hash(state);
     }
 }
-
-impl ApiResult for Origin {}
-impl ApiResult for Pool {}

--- a/cloudflare/src/endpoints/r2.rs
+++ b/cloudflare/src/endpoints/r2.rs
@@ -1,5 +1,6 @@
 use chrono::offset::Utc;
 use chrono::DateTime;
+use cloudflare_derive_macros::ApiResult;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -16,14 +17,13 @@ pub struct Bucket {
 }
 
 /// ListBucketsResult contains a list of buckets in an account.
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ApiResult)]
 pub struct ListBucketsResult {
     pub buckets: Vec<Bucket>,
 }
 
 type EmptyMap = HashMap<(), ()>;
 impl ApiResult for EmptyMap {}
-impl ApiResult for ListBucketsResult {}
 
 /// Lists all buckets within the account.
 #[derive(Debug)]

--- a/cloudflare/src/endpoints/user.rs
+++ b/cloudflare/src/endpoints/user.rs
@@ -1,7 +1,7 @@
 use crate::framework::endpoint::{EndpointSpec, Method};
-use crate::framework::response::ApiResult;
 
 use chrono::{DateTime, Utc};
+use cloudflare_derive_macros::ApiResult;
 use serde::{Deserialize, Serialize};
 
 /// Get User Details
@@ -17,7 +17,7 @@ pub struct Organization {
     roles: Vec<String>, // List of role names for the User at the Organization
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ApiResult)]
 pub struct UserDetails {
     pub organizations: Vec<Organization>,
     #[serde(default)]
@@ -35,7 +35,6 @@ pub struct UserDetails {
     pub suspended: bool,
     pub email: String,
 }
-impl ApiResult for UserDetails {}
 
 #[test]
 fn handles_empty_betas_field() {
@@ -81,12 +80,11 @@ impl EndpointSpec<UserDetails> for GetUserDetails {
 /// Returns whether a given token is valid or not.
 /// <https://blog.cloudflare.com/api-tokens-general-availability/>
 ///
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ApiResult)]
 pub struct UserTokenStatus {
     pub id: String,
     pub status: String,
 }
-impl ApiResult for UserTokenStatus {}
 
 #[derive(Debug)]
 pub struct GetUserTokenStatus {}

--- a/cloudflare/src/endpoints/workers/delete_script.rs
+++ b/cloudflare/src/endpoints/workers/delete_script.rs
@@ -1,6 +1,6 @@
 use crate::framework::endpoint::{EndpointSpec, Method};
-use crate::framework::response::ApiResult;
 
+use cloudflare_derive_macros::ApiResult;
 use serde::{Deserialize, Serialize};
 
 /// Delete Workers script
@@ -25,8 +25,7 @@ impl<'a> EndpointSpec<ScriptDeleteID> for DeleteScript<'a> {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ApiResult)]
 pub struct ScriptDeleteID {
     pub id: String,
 }
-impl ApiResult for ScriptDeleteID {}

--- a/cloudflare/src/endpoints/workers/mod.rs
+++ b/cloudflare/src/endpoints/workers/mod.rs
@@ -1,6 +1,5 @@
-use crate::framework::response::ApiResult;
-
 use chrono::{DateTime, Utc};
+use cloudflare_derive_macros::{ApiResult, VecApiResult};
 use serde::{Deserialize, Serialize};
 
 mod create_route;
@@ -34,7 +33,7 @@ pub use send_tail_heartbeat::SendTailHeartbeat;
 /// Workers KV Route
 /// Routes are basic patterns used to enable or disable workers that match requests.
 /// <https://api.cloudflare.com/#worker-routes-properties>
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ApiResult, VecApiResult)]
 pub struct WorkersRoute {
     /// Namespace identifier tag.
     pub id: String,
@@ -45,52 +44,47 @@ pub struct WorkersRoute {
     pub script: Option<String>,
 }
 
-impl ApiResult for WorkersRoute {}
-impl ApiResult for Vec<WorkersRoute> {}
-
 /// A variant of WorkersRoute returned by the CreateRoute endpoint
 /// We could make `pattern` and `script` into `Option<String>` types
 /// but it feels wrong.
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ApiResult)]
 pub struct WorkersRouteIdOnly {
     /// Namespace identifier tag.
     pub id: String,
 }
 
-impl ApiResult for WorkersRouteIdOnly {}
-
 /// Secrets attach to a single script to be readable in only the script
 /// <https://api.cloudflare.com/#worker-secrets-properties>
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(
+    Deserialize,
+    Serialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    ApiResult,
+    VecApiResult, /* to parse arrays too */
+)]
 pub struct WorkersSecret {
     pub name: String,
     #[serde(rename = "type")]
     pub secret_type: String,
 }
 
-impl ApiResult for WorkersSecret {}
-impl ApiResult for Vec<WorkersSecret> {} // to parse arrays too
-
 /// A Tail is attached to a single Worker and is impermanent
 /// <https://api.cloudflare.com/#worker-tail-properties>
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ApiResult, VecApiResult)]
 pub struct WorkersTail {
     pub id: String,
     pub url: Option<String>,
     pub expires_at: DateTime<Utc>,
 }
 
-impl ApiResult for WorkersTail {}
-impl ApiResult for Vec<WorkersTail> {}
-
 // Binding for a Workers Script
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ApiResult, VecApiResult)]
 pub struct WorkersBinding {
     pub name: String,
     pub r#type: String,
     pub namespace_id: String,
     pub class_name: Option<String>,
 }
-
-impl ApiResult for WorkersBinding {}
-impl ApiResult for Vec<WorkersBinding> {}

--- a/cloudflare/src/endpoints/workerskv/mod.rs
+++ b/cloudflare/src/endpoints/workerskv/mod.rs
@@ -1,6 +1,6 @@
-use crate::framework::response::ApiResult;
 use chrono::DateTime;
 use chrono::{TimeZone, Utc};
+use cloudflare_derive_macros::{ApiResult, VecApiResult};
 use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -41,7 +41,7 @@ const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
 /// Workers KV Namespace
 /// A Namespace is a collection of key-value pairs stored in Workers KV.
 /// <https://api.cloudflare.com/#workers-kv-namespace-properties>
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ApiResult, VecApiResult)]
 pub struct WorkersKvNamespace {
     /// Namespace identifier tag.
     pub id: String,
@@ -49,12 +49,8 @@ pub struct WorkersKvNamespace {
     pub title: String,
 }
 
-impl ApiResult for WorkersKvNamespace {}
-
-impl ApiResult for Vec<WorkersKvNamespace> {}
-
 #[serde_with::skip_serializing_none]
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, ApiResult, VecApiResult)]
 pub struct Key {
     pub name: String,
     #[serde(default)]
@@ -75,10 +71,6 @@ where
 
     Ok(None)
 }
-
-impl ApiResult for Key {}
-
-impl ApiResult for Vec<Key> {}
 
 fn url_encode_key(key: &str) -> String {
     percent_encode(key.as_bytes(), PATH_SEGMENT_ENCODE_SET).to_string()

--- a/cloudflare/src/endpoints/zone.rs
+++ b/cloudflare/src/endpoints/zone.rs
@@ -1,12 +1,10 @@
 use crate::endpoints::{account::AccountDetails, plan::Plan};
 use crate::framework::endpoint::serialize_query;
-use crate::framework::{
-    endpoint::{EndpointSpec, Method},
-    response::ApiResult,
-};
+use crate::framework::endpoint::{EndpointSpec, Method};
 use crate::framework::{OrderDirection, SearchMatch};
 use chrono::offset::Utc;
 use chrono::DateTime;
+use cloudflare_derive_macros::{ApiResult, VecApiResult};
 use serde::{Deserialize, Serialize};
 
 /// List Zones
@@ -142,7 +140,7 @@ pub struct Meta {
 
 /// A Zone is a domain name along with its subdomains and other identities
 /// <https://api.cloudflare.com/#zone-properties>
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, ApiResult, VecApiResult)]
 pub struct Zone {
     /// Zone identifier tag
     pub id: String,
@@ -196,7 +194,3 @@ pub struct Zone {
     #[serde(rename = "type")]
     pub zone_type: Type,
 }
-
-// TODO: This should probably be a derive macro
-impl ApiResult for Zone {}
-impl ApiResult for Vec<Zone> {}


### PR DESCRIPTION
Had to add an extra crate to define the proc macro.
Wasn't sure about the name of the macro to derive `Vec<...>` and ended up with `VecApiResult`. If someone comes up with something better I'd be happy to change it.