### PR TITLE
zone: make Owner fields optional

### DIFF
--- a/cloudflare/src/endpoints/zone.rs
+++ b/cloudflare/src/endpoints/zone.rs
@@ -109,8 +109,14 @@ pub enum Status {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "lowercase", tag = "type")]
 pub enum Owner {
-    User { id: String, email: String },
-    Organization { id: String, name: String },
+    User {
+        id: Option<String>,
+        email: Option<String>,
+    },
+    Organization {
+        id: Option<String>,
+        name: Option<String>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
According to the [docs](https://developers.cloudflare.com/api/operations/zones-0-get) `id` and `name` are not required and `email` isn't even mentioned. My request had `id` and `email` as null, which broke deserialization 

```json
      "owner": { "id": null, "type": "user", "email": null },
```

~The correct thing to do would be to make these fields `Option<String>` but I didn't do so in order not to break the api.~ Had to convert the fields to Option<String>, which breaks the public API, but I doubt anyone is using the Owner struct tbh.

This is also how the go implementation does it too: 

https://github.com/cloudflare/cloudflare-go/blob/325729d2e358cd3f300c130cfa828e5704e725d8/zone.go#L24-L29

If any of the fields are `null`, the go json library will just make that field an empty string.