### PR TITLE
Update broken Zone entry struct

### DIFF
--- a/cloudflare/src/endpoints/zone.rs
+++ b/cloudflare/src/endpoints/zone.rs
@@ -109,8 +109,14 @@ pub enum Status {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "lowercase", tag = "type")]
 pub enum Owner {
-    User { id: String, email: String },
-    Organization { id: String, name: String },
+    User {
+        id: Option<String>,
+        email: Option<String>,
+    },
+    Organization {
+        id: String,
+        name: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -136,8 +142,6 @@ pub struct Meta {
     pub page_rule_quota: u32,
     /// Indicates if URLs on the zone have been identified as hosting phishing content.
     pub phishing_detected: bool,
-    /// Indicates whether the zone is allowed to be connected to multiple Railguns at once
-    pub multiple_railguns_allowed: bool,
 }
 
 /// A Zone is a domain name along with its subdomains and other identities
@@ -150,6 +154,8 @@ pub struct Zone {
     pub name: String,
     /// Information about the account the zone belongs to
     pub account: AccountDetails,
+    /// The last time proof of ownership was detected and the zone was made active
+    pub activated_on: DateTime<Utc>,
     /// A list of beta features in which the zone is participating
     pub betas: Option<Vec<String>>,
     /// When the zone was created

--- a/cloudflare/src/endpoints/zone.rs
+++ b/cloudflare/src/endpoints/zone.rs
@@ -114,8 +114,8 @@ pub enum Owner {
         email: Option<String>,
     },
     Organization {
-        id: String,
-        name: String,
+        id: Option<String>,
+        name: Option<String>,
     },
 }
 


### PR DESCRIPTION
Does the following:
 - Removes the `multiple_railguns_allowed` field, as it appears to be removed. Fixes #236
 - Makes the fields of the `owner` field optional (#232), as otherwise the examples would still not work
 - Adds the `activated_on` field

There are some more discrepancies, i.e. fields on the docs that don't exist here, and fields here that don't exist in the docs, but I want to refrain from changing too much. 



This can be tested with the `cloudflare-examples` cli:

<details>
<summary>Before</summary>

```
$ cargo run --bin cloudflare-examples -- --auth-token=XXX zone XXX
   Compiling cloudflare v0.12.0 (/home/wp/programming/cloudflare-rs/cloudflare)
   Compiling cloudflare-examples v0.6.0 (/home/wp/programming/cloudflare-rs/cloudflare-examples)
    Finished dev [unoptimized + debuginfo] target(s) in 3.45s
     Running `target/debug/cloudflare-examples --auth-token=XXX zone XXX`
Error: error decoding response body: missing field `multiple_railguns_allowed` at line 1 column 585
```
</details>

<details>
<summary>After</summary>

```
$cargo run --bin cloudflare-examples -- --auth-token=XXX zone XXX
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/cloudflare-examples --auth-token=XXX zone XXX`
Success: ApiSuccess {
    result: Zone {
        id: "XXX",
        name: "XXX",
        account: AccountDetails {
            id: "XXX",
            name: "XXX",
        },
        activated_on: 2021-08-22T18:52:08.877823Z,
        betas: None,
        created_on: 2021-08-22T18:48:11.312863Z,
        deactivation_reason: None,
        development_mode: 0,
        host: None,
        meta: Meta {
            custom_certificate_quota: 0,
            page_rule_quota: 3,
            phishing_detected: false,
        },
        modified_on: 2021-08-22T18:52:08.877823Z,
        name_servers: [
            "pedro.ns.cloudflare.com",
            "surina.ns.cloudflare.com",
        ],
        original_dnshost: None,
        original_name_servers: Some(
            [
                "ns13.domaincontrol.com",
                "ns14.domaincontrol.com",
            ],
        ),
        original_registrar: Some(
            "namecheap, inc. (id: 1068)",
        ),
        owner: User {
            id: None,
            email: None,
        },
        paused: false,
        permissions: [
            "#dns_records:edit",
            "#dns_records:read",
            "#zone:read",
        ],
        plan: Some(
            Plan {
                id: "0feeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
                name: "Free Website",
                price: 0.0,
                currency: "USD",
                frequency: Some(
                    Nil,
                ),
                legacy_id: "free",
                is_subscribed: false,
                can_subscribe: false,
            },
        ),
        plan_pending: None,
        status: Active,
        vanity_name_servers: None,
        zone_type: Full,
    },
    result_info: None,
    messages: Array [],
    errors: [],
}
```
</details>
