### PR TITLE
add repo field to Manifest

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -7,6 +7,7 @@ description = "Rust library for the Cloudflare v4 API"
 keywords = ["cloudflare", "api", "client"]
 categories = ["api-bindings", "web-programming::http-client"]
 license = "BSD-3-Clause"
+repository = "https://github.com/cloudflare/cloudflare-rs"
 
 [features]
 default = ["default-tls"]


### PR DESCRIPTION
It's missing the repo field, which means it's missing from crates.io and docs.rs