### PR TITLE
fix(cloudflare): Remove `zone_id` and `zone_name` in DNSRecord

### DIFF
--- a/cloudflare/src/endpoints/dns.rs
+++ b/cloudflare/src/endpoints/dns.rs
@@ -188,8 +188,6 @@ pub struct DnsRecord {
     pub name: String,
     /// Time to live for DNS record. Value of 1 is 'automatic'
     pub ttl: u32,
-    /// Zone identifier tag
-    pub zone_id: String,
     /// When the record was last modified
     pub modified_on: DateTime<Utc>,
     /// When the record was created
@@ -203,8 +201,6 @@ pub struct DnsRecord {
     pub id: String,
     /// Whether the record is receiving the performance and security benefits of Cloudflare
     pub proxied: bool,
-    /// The domain of the record
-    pub zone_name: String,
 }
 
 impl ApiResult for DnsRecord {}


### PR DESCRIPTION
As https://developers.cloudflare.com/changelog/ said on 27th, Jan, 2025, "Records returned by the API will no longer contain the zone_id and zone_name fields.", so we need to remove it to avoid parse error.

ref #251 