### PR TITLE
feat: endpoints for Workers Schedules

### DIFF
--- a/cloudflare/src/endpoints/workers/list_schedules.rs
+++ b/cloudflare/src/endpoints/workers/list_schedules.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+
+use super::WorkersSchedule;
+
+use crate::framework::{
+    endpoint::{EndpointSpec, Method},
+    response::{ApiResult, ApiSuccess},
+};
+
+/// List Schedules
+/// <https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/schedules/methods/get/>
+#[derive(Debug)]
+pub struct ListSchedules<'a> {
+    /// Account ID of owner of the script
+    pub account_identifier: &'a str,
+    /// The name of the script to list the schedules
+    pub script_name: &'a str,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ListSchedulesResponse {
+    pub schedules: Vec<WorkersSchedule>,
+}
+
+impl ApiResult for ListSchedulesResponse {}
+
+impl EndpointSpec for ListSchedules<'_> {
+    type JsonResponse = ListSchedulesResponse;
+    type ResponseType = ApiSuccess<Self::JsonResponse>;
+
+    fn method(&self) -> Method {
+        Method::GET
+    }
+
+    fn path(&self) -> String {
+        format!(
+            "accounts/{}/workers/scripts/{}/schedules",
+            self.account_identifier, self.script_name
+        )
+    }
+}

--- a/cloudflare/src/endpoints/workers/mod.rs
+++ b/cloudflare/src/endpoints/workers/mod.rs
@@ -13,9 +13,11 @@ mod delete_secret;
 mod delete_tail;
 mod list_bindings;
 mod list_routes;
+mod list_schedules;
 mod list_secrets;
 mod list_tails;
 mod send_tail_heartbeat;
+mod update_schedules;
 
 pub use create_route::{CreateRoute, CreateRouteParams};
 pub use create_secret::{CreateSecret, CreateSecretParams};
@@ -27,9 +29,11 @@ pub use delete_secret::DeleteSecret;
 pub use delete_tail::DeleteTail;
 pub use list_bindings::ListBindings;
 pub use list_routes::ListRoutes;
+pub use list_schedules::{ListSchedules, ListSchedulesResponse};
 pub use list_secrets::ListSecrets;
 pub use list_tails::ListTails;
 pub use send_tail_heartbeat::SendTailHeartbeat;
+pub use update_schedules::{UpdateSchedules, UpdateSchedulesResponse};
 
 /// Workers KV Route
 /// Routes are basic patterns used to enable or disable workers that match requests.
@@ -156,6 +160,17 @@ pub enum WorkersBinding {
 
 impl ApiResult for WorkersBinding {}
 impl ApiResult for Vec<WorkersBinding> {}
+
+// Schedule for a Workers Script
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Default, PartialOrd, Ord)]
+pub struct WorkersSchedule {
+    pub cron: Option<String>,
+    pub created_on: Option<String>,
+    pub modified_on: Option<String>,
+}
+
+impl ApiResult for WorkersSchedule {}
+impl ApiResult for Vec<WorkersSchedule> {}
 
 #[cfg(test)]
 mod tests {

--- a/cloudflare/src/endpoints/workers/update_schedules.rs
+++ b/cloudflare/src/endpoints/workers/update_schedules.rs
@@ -1,0 +1,49 @@
+use serde::Deserialize;
+
+use super::WorkersSchedule;
+
+use crate::framework::{
+    endpoint::{EndpointSpec, Method, RequestBody},
+    response::{ApiResult, ApiSuccess},
+};
+
+/// Update Schedules
+/// <https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/schedules/methods/update/>
+#[derive(Debug)]
+pub struct UpdateSchedules<'a> {
+    /// Account ID of owner of the script
+    pub account_identifier: &'a str,
+    /// Name of the script, used in URLs and route configuration.
+    pub script_name: &'a str,
+    /// Schedules to be updated
+    pub schedules: Vec<WorkersSchedule>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateSchedulesResponse {
+    pub schedules: Vec<WorkersSchedule>,
+}
+
+impl ApiResult for UpdateSchedulesResponse {}
+
+impl EndpointSpec for UpdateSchedules<'_> {
+    type JsonResponse = UpdateSchedulesResponse;
+    type ResponseType = ApiSuccess<Self::JsonResponse>;
+
+    fn method(&self) -> Method {
+        Method::PUT
+    }
+
+    fn path(&self) -> String {
+        format!(
+            "accounts/{}/workers/scripts/{}/schedules",
+            self.account_identifier, self.script_name
+        )
+    }
+
+    #[inline]
+    fn body(&self) -> Option<RequestBody> {
+        let body = serde_json::to_string(&self.schedules).unwrap();
+        Some(RequestBody::Json(body))
+    }
+}


### PR DESCRIPTION
### Description
This adds support to endpoints for listing and creating/updating [Workers Schedules](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/schedules).

### References
- https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/schedules
- https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/schedules/methods/get
- https://developers.cloudflare.com/api/resources/workers/subresources/scripts/subresources/schedules/methods/update