### PR TITLE
feat: ListDnsRecords support different matches on name

### DIFF
--- a/cloudflare/src/endpoints/dns/dns.rs
+++ b/cloudflare/src/endpoints/dns/dns.rs
@@ -152,13 +152,27 @@ pub enum ListDnsRecordsOrder {
 pub struct ListDnsRecordsParams {
     #[serde(flatten)]
     pub record_type: Option<DnsContent>,
-    pub name: Option<String>,
+    #[serde(flatten)]
+    pub name: Option<ListDnsRecordsParamsName>,
     pub page: Option<u32>,
     pub per_page: Option<u32>,
     pub order: Option<ListDnsRecordsOrder>,
     pub direction: Option<OrderDirection>,
     #[serde(rename = "match")]
     pub search_match: Option<SearchMatch>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Clone, Debug, Default)]
+pub struct ListDnsRecordsParamsName {
+    #[serde(rename = "name.contains")]
+    pub contains: Option<String>,
+    #[serde(rename = "name.startswith")]
+    pub starts_with: Option<String>,
+    #[serde(rename = "name.endswith")]
+    pub ends_with: Option<String>,
+    #[serde(rename = "name.exact")]
+    pub exact: Option<String>,
 }
 
 /// Extra Cloudflare-specific information about the record


### PR DESCRIPTION
### Description
Currently the `ListDnsRecordsParams` send `name` as a string. This works I'm guessing because of backwards compatibility, but it seems like this is [not a documented way anymore](https://developers.cloudflare.com/api/resources/dns/subresources/records/methods/list/#(resource)%20dns.records%20%3E%20(method)%20list%20%3E%20(params)%20default%20%3E%20(param)%20name%20%3E%20(schema)).

The documentation expects `name` to contain:
- `contains`: Substring of the DNS record name.
- `endswith`: Suffix of the DNS record name.
- `exact`: Exact value of the DNS record name.
- `startswith`: Prefix of the DNS record name.

With the current implementation, the only supported is `exact`, as it seems like that is the behavior if `name` is sent as a string.

### Why flatten?
[`serde_urlencoded`](https://github.com/nox/serde_urlencoded) does not seem to support nested objects. Also seems like they are not really maintained anymore. Could be interesting to change to [serde_qs](https://docs.rs/serde_qs/latest/serde_qs) as a separate effort.
> This crate is a Rust library for serialising to and deserialising from querystrings using serde. This crate is designed to extend serde_urlencoded when using nested parameters

### References:
- https://developers.cloudflare.com/api/resources/dns/subresources/records/methods/list/#(resource)%20dns.records%20%3E%20(method)%20list%20%3E%20(params)%20default%20%3E%20(param)%20name%20%3E%20(schema)
- https://github.com/nox/serde_urlencoded
- https://docs.rs/serde_qs/latest/serde_qs