### PR TITLE
refactor(deps): replace serde_urlencoded with serde_qs

### DIFF
--- a/cloudflare/Cargo.toml
+++ b/cloudflare/Cargo.toml
@@ -31,7 +31,7 @@ reqwest = { version = "0.12.12", default-features = false, features = ["json", "
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3", features = ["base64"] }
-serde_urlencoded = "0.7.1"
+serde_qs = "1.1"
 thiserror = "2"
 url = "2.2"
 urlencoding = "2.1.3"

--- a/cloudflare/src/framework/endpoint.rs
+++ b/cloudflare/src/framework/endpoint.rs
@@ -111,5 +111,5 @@ pub trait Endpoint<ResultType: ApiResult>: EndpointSpec {}
 /// A utility function for serializing parameters into a URL query string.
 #[inline]
 pub fn serialize_query<Q: Serialize>(q: &Q) -> Option<String> {
-    serde_urlencoded::to_string(q).ok()
+    serde_qs::to_string(q).ok()
 }


### PR DESCRIPTION
### Description
While working on https://github.com/cloudflare/cloudflare-rs/pull/290 I faced the issue of serializing nested structs with `serde_urlencoded`. It is not supported by it, and iself seems to be unmaintained.

It seems like the "modern" one for serializing query parameters is `serde_qs`. So this PR proposes the change to it.

### References
- https://github.com/nox/serde_urlencoded
- https://github.com/nox/serde_urlencoded/issues/121
- https://github.com/samscott89/serde_qs